### PR TITLE
Crasher fix

### DIFF
--- a/MPLib/MixpanelAPI.m
+++ b/MPLib/MixpanelAPI.m
@@ -328,10 +328,12 @@ NSString* calculateHMAC_SHA1(NSString *str, NSString *key) {
 {
 	#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 40000
   if ([self flushOnBackground]) {
-    if ([[UIApplication sharedApplication] respondsToSelector:@selector(beginBackgroundTaskWithExpirationHandler:)]) {
+    if ([[UIApplication sharedApplication] respondsToSelector:@selector(beginBackgroundTaskWithExpirationHandler:)] &&
+        [[UIApplication sharedApplication] respondsToSelector:@selector(endBackgroundTask:)]) {
       taskId = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
         [self.connection cancel];
         [self archiveData];
+        [[UIApplication sharedApplication] endBackgroundTask:taskId];
       }]	;
       [self flush];
     } else {


### PR DESCRIPTION
Add endBackgroundTask to expiration handler

iOS kills our app because Mixpanel does not signal the background task
termination when the expiration handler runs.

The crash logs show:
has active assertions beyond permitted time:
    {(
        <SBProcessAssertion: 0xcdc7ea0> identifier: UIKitBackgroundCompletionTask process: permittedBackgroundDuration: 600.000000 reason: finishTask owner pid:888 preventSuspend  preventIdleSleep
    )}
