### PR TITLE
Flag to globally disable events tracking

### DIFF
--- a/MPLib/MixpanelAPI.h
+++ b/MPLib/MixpanelAPI.h
@@ -37,6 +37,7 @@ static const NSUInteger kMPUploadInterval = 30;
 	NSString *defaultUserId;
 	NSUInteger uploadInterval;
 	BOOL testMode;
+	BOOL trackEvents;
 }
 /*! @property uploadInterval
 	@abstract The upload interval in seconds.
@@ -61,6 +62,12 @@ static const NSUInteger kMPUploadInterval = 30;
 	@discussion Changing this value enables/disables test mode for future flushes.
 */
 @property(nonatomic) BOOL testMode;
+
+/*! @property trackEvents
+	@abstract Whether tracking of events is on
+	@discussion Changing this value enables/disables tracking of events. Defaults to YES.
+*/
+@property(nonatomic) BOOL trackEvents;
 
 /*!
     @method     sharedAPIWithToken:

--- a/MPLib/MixpanelAPI.m
+++ b/MPLib/MixpanelAPI.m
@@ -53,6 +53,7 @@
 @synthesize uploadInterval;
 @synthesize flushOnBackground;
 @synthesize testMode;
+@synthesize trackEvents;
 static MixpanelAPI *sharedInstance = nil; 
 
 NSString* calculateHMAC_SHA1(NSString *str, NSString *key) {
@@ -191,6 +192,7 @@ NSString* calculateHMAC_SHA1(NSString *str, NSString *key) {
 			self.eventQueue = [NSMutableArray array];
 			self.superProperties = [NSMutableDictionary dictionary];
 			self.flushOnBackground = YES;
+			self.trackEvents = YES;
 			uploadInterval = kMPUploadInterval;
 			[self.superProperties setObject:@"iphone" forKey:@"mp_lib"];
 			NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
@@ -266,6 +268,10 @@ NSString* calculateHMAC_SHA1(NSString *str, NSString *key) {
 
 - (void)track:(NSString*) event properties:(NSDictionary*) properties
 {
+	if (!self.trackEvents) {
+		return;
+	}
+	
 	NSMutableDictionary *props = [NSMutableDictionary dictionary];
 	[props addEntriesFromDictionary:superProperties];
 	[props addEntriesFromDictionary:properties];


### PR DESCRIPTION
Can be useful to be able to disable events tracking globally with a single flag.
This patch does exactly this, adds a property "trackEvents" which is checked every time in "track:" method.

The background for this is an app can have a switch (in the settings) so users can disable gathering of (anonymous) usage statistics. That would be nice to avoid wrapping every "track:" method in "if" statements, but set the state for MixpanelAPI just once.
