### PR TITLE
Fix static analyzer warning

### DIFF
--- a/MPLib/lib/NSData_Base64/NSData+MPBase64.m
+++ b/MPLib/lib/NSData_Base64/NSData+MPBase64.m
@@ -88,6 +88,7 @@ void *MP_NewBase64Decode(
 		// Accumulate 4 valid characters (ignore everything else)
 		//
 		unsigned char accumulated[BASE64_UNIT_SIZE];
+        memset(accumulated, 0, sizeof(unsigned char) * BASE64_UNIT_SIZE);
 		size_t accumulateIndex = 0;
 		while (i < length)
 		{


### PR DESCRIPTION
XCode's "Analyze" action discovers several issues in "MPLib/lib/NSData_Base64/NSData+MPBase64.m"
They all can be fixed by nullifying respective array with a single line.

iOS developers usually do Analyze before submitting their app to review and issues in a lib would not make them happy.

(This is not my solution, but I've just merged it to my fork from another fork https://github.com/appsocial/mixpanel-iphone/commit/6fe14abc1a3e3003c5389453d84e79079b16818a)
