### PR TITLE
Option to disable network activity indicator

### DIFF
--- a/MPLib/MixpanelAPI.h
+++ b/MPLib/MixpanelAPI.h
@@ -36,6 +36,7 @@ static const NSUInteger kMPUploadInterval = 30;
 	#endif
 	NSString *defaultUserId;
 	NSUInteger uploadInterval;
+	BOOL showNetworkActivityIndicator;
 	BOOL testMode;
 }
 /*! @property uploadInterval
@@ -61,6 +62,12 @@ static const NSUInteger kMPUploadInterval = 30;
 	@discussion Changing this value enables/disables test mode for future flushes.
 */
 @property(nonatomic) BOOL testMode;
+
+/*! @property showNetworkActivityIndicator
+	@abstract Whether the network activity indicator will be displayed during network activity.
+	@discussion Changing this value enables/disables the network activity indicator for future flushes.
+*/
+@property(nonatomic) BOOL showNetworkActivityIndicator;
 
 /*!
     @method     sharedAPIWithToken:

--- a/MPLib/MixpanelAPI.m
+++ b/MPLib/MixpanelAPI.m
@@ -54,6 +54,7 @@ NSString* calculateHMAC_SHA1(NSString *str, NSString *key);
 @synthesize uploadInterval;
 @synthesize flushOnBackground;
 @synthesize testMode;
+@synthesize showNetworkActivityIndicator;
 static MixpanelAPI *sharedInstance = nil; 
 
 NSString* calculateHMAC_SHA1(NSString *str, NSString *key) {
@@ -347,7 +348,7 @@ NSString* calculateHMAC_SHA1(NSString *str, NSString *key) {
 	MPCJSONDataSerializer *serializer = [MPCJSONDataSerializer serializer];
 	NSData *data = [serializer serializeArray:[eventsToSend valueForKey:@"dictionaryValue"]
                                         error:nil];
-	[[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:YES];
+	[[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:self.showNetworkActivityIndicator ? YES : NO];
 	NSString *urlString = SERVER_URL;
 	NSString *postBody = [NSString stringWithFormat:@"ip=1&data=%@", [data mp_base64EncodedString]];
 	if (self.testMode) {


### PR DESCRIPTION
Added a configurable option to disable showing the network activity indicator.

Also removed a compiler warning.
