### PR TITLE
Added an additional function removeSuperPropertyForKey and also an assert for checking when the postBody become empty

### DIFF
--- a/MPLib/MixpanelAPI.h
+++ b/MPLib/MixpanelAPI.h
@@ -117,6 +117,8 @@ static const NSUInteger kMPUploadInterval = 30;
  */
 - (void)registerSuperPropertiesOnce:(NSDictionary*) properties defaultValue:(id) defaultValue;
 
+-(void)removeSuperPropertyForKey:(NSString*)key;
+
 /*!
 	@method     identifyUser:
 	@abstract   Identifies a user.

--- a/MPLib/MixpanelAPI.m
+++ b/MPLib/MixpanelAPI.m
@@ -356,6 +356,7 @@ NSString* calculateHMAC_SHA1(NSString *str, NSString *key) {
 	NSString *postBody = [NSString stringWithFormat:@"ip=1&data=%@", [data mp_base64EncodedString]];
 	if (self.testMode) {
 		NSLog(@"Mixpanel test mode is enabled");
+        NSAssert([postBody length], @"Failed to serialize MixPanel events!");
 		postBody = [NSString stringWithFormat:@"test=1&%@", postBody];
 	}
 	NSURL *url = [NSURL URLWithString:urlString];

--- a/MPLib/MixpanelAPI.m
+++ b/MPLib/MixpanelAPI.m
@@ -253,6 +253,11 @@ NSString* calculateHMAC_SHA1(NSString *str, NSString *key) {
     }
 }
 
+-(void)removeSuperPropertyForKey:(NSString*)key
+{
+    NSAssert(key != nil, @"Key should not be nil");
+    [self.superProperties removeObjectForKey:key];
+}
 
 - (void)identifyUser:(NSString*) identifier
 {


### PR DESCRIPTION
- Added removeSuperPropertyForKey
- Added NSAssert to ensure postBody is not empty due to failed encoding