### PR TITLE
Fix two bugs.

### DIFF
--- a/MPLib/MixpanelAPI.m
+++ b/MPLib/MixpanelAPI.m
@@ -351,6 +351,7 @@ NSString* getPlatform()
             [[UIApplication sharedApplication] respondsToSelector:@selector(endBackgroundTask:)]) {
             taskId = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
                 [self.connection cancel];
+                self.connection = nil;
                 [self archiveData];
                 [[UIApplication sharedApplication] endBackgroundTask:taskId];
                 taskId = UIBackgroundTaskInvalid;
@@ -421,7 +422,6 @@ NSString* getPlatform()
 	[request setHTTPMethod:@"POST"];
 	[request setHTTPBody:[postBody dataUsingEncoding:NSUTF8StringEncoding]];
 	self.connection = [NSURLConnection connectionWithRequest:request delegate:self];
-	[self.connection start];
 	[request release];
 	
 }


### PR DESCRIPTION
1. The expiration handler for beginBackgroundTask was cancelling the connection, but not setting self.connection = nil, which would prevent all future connections from going out.
2. Remove an extraneous attempt to start a NSURLConnection. [NSURLConnection connectionWithRequest:delegate:] creates a connection that is started immediately, and the documentation is unclear as to whether start is an idempotent method.
