### PR TITLE
Initialize outputLength to zero.

### DIFF
--- a/MPLib/lib/NSData_Base64/NSData+MPBase64.m
+++ b/MPLib/lib/NSData_Base64/NSData+MPBase64.m
@@ -281,7 +281,7 @@ char *MP_NewBase64Encode(
 //
 - (NSString *)mp_base64EncodedString
 {
-	size_t outputLength;
+	size_t outputLength = 0;
 	char *outputBuffer =
 		MP_NewBase64Encode([self bytes], [self length], false, &outputLength);
 	


### PR DESCRIPTION
This fixes a static analyzer warning in Xcode 4.4.
