### PR TITLE
Include optional printing of events.

### DIFF
--- a/MPLib/MixpanelAPI.h
+++ b/MPLib/MixpanelAPI.h
@@ -155,6 +155,14 @@ static const NSUInteger kMPUploadInterval = 30;
  @discussion Tells the Mixpane API to send the device model as a super property.
  */
 @property(nonatomic, assign) BOOL sendDeviceModel;
+
+/*! 
+ @property   printEvents
+ @abstract   Prints the details of any events logged to the console.
+ @discussion Prints the details of any events logged to the console.
+ */
+@property(nonatomic, assign) BOOL printEvents;
+
 /*!
  @method     sharedAPIWithToken:
  @abstract   Initializes the API with your API Token. Returns the shared API object.

--- a/MPLib/MixpanelAPI.m
+++ b/MPLib/MixpanelAPI.m
@@ -45,6 +45,7 @@
 @synthesize delegate;
 @synthesize testMode;
 @synthesize sendDeviceModel;
+@synthesize printEvents;
 
 static MixpanelAPI *sharedInstance = nil; 
 
@@ -301,6 +302,9 @@ static MixpanelAPI *sharedInstance = nil;
 }
 
 - (void)track:(NSString*) event properties:(NSDictionary*) properties {
+    if (self.printEvents) {
+	   NSLog(@"Mixpanel: Track \"%@\", Properties %@", event, properties ?: @"none");
+    }
 	NSMutableDictionary *props = [NSMutableDictionary dictionary];
 	[props addEntriesFromDictionary:superProperties];
 	[props addEntriesFromDictionary:properties];


### PR DESCRIPTION
It can be useful for debugging purposes to see the events logged in the console. So, I've added a property `printEvents` to `MixpanelAPI`, and when it is set to `YES` you will get a the event name and properties logged in the console.
