### PR TITLE
Make super properties readable

### DIFF
--- a/MPLib/MixpanelAPI.h
+++ b/MPLib/MixpanelAPI.h
@@ -155,6 +155,14 @@ static const NSUInteger kMPUploadInterval = 30;
  @discussion Tells the Mixpane API to send the device model as a super property.
  */
 @property(nonatomic, assign) BOOL sendDeviceModel;
+
+/*! 
+ @property   superProperties
+ @abstract   Returns the superProperties dictionary
+ @discussion Returns a non-mutable copy - Modification must be done through the various setSuperProperties methods
+ */
+-(NSDictionary*) getSuperProperties;
+
 /*!
  @method     sharedAPIWithToken:
  @abstract   Initializes the API with your API Token. Returns the shared API object.

--- a/MPLib/MixpanelAPI.m
+++ b/MPLib/MixpanelAPI.m
@@ -280,6 +280,11 @@ static MixpanelAPI *sharedInstance = nil;
     }
 }
 
+-(NSDictionary*) getSuperProperties
+{
+    return self.superProperties;
+}
+
 - (void)identifyUser:(NSString*) identifier {
     [self registerSuperProperties:[NSDictionary dictionaryWithObject:identifier forKey:@"distinct_id"]];
 }


### PR DESCRIPTION
You may want to rewrite this, but I think the feature is useful. I need to read the super properties so I can get at the user identity.
