### PR TITLE
Updated to use CFBundleShortVersionString vs CFBundleVersion.

### DIFF
--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -1049,7 +1049,7 @@ static Mixpanel *sharedInstance = nil;
     NSMutableDictionary *properties = [NSMutableDictionary dictionary];
     [properties setValue:[Mixpanel deviceModel] forKey:@"$ios_device_model"];
     [properties setValue:[device systemVersion] forKey:@"$ios_version"];
-    [properties setValue:[[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleVersion"] forKey:@"$ios_app_version"];
+    [properties setValue:[[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"] forKey:@"$ios_app_version"];
     return [NSDictionary dictionaryWithDictionary:properties];
 }
 


### PR DESCRIPTION
A lot of apps use CFBundleVersion as a build number especially when doing automatic build numbers so the real value needed is from CFBundleShortVersionString.

It might be worth sending both values but for now, I've updated it for just the one.
