### PR TITLE
-(void)applicationWillTerminate: is not called for applications that support background execution

### DIFF
--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -845,7 +845,8 @@ static Mixpanel *sharedInstance = nil;
     MixpanelDebug(@"%@ did enter background", self);
 
     @synchronized(self) {
-
+        [self archive];
+        
 #if __IPHONE_OS_VERSION_MIN_REQUIRED >= 40000
         if (self.flushOnBackground &&
             [[UIApplication sharedApplication] respondsToSelector:@selector(beginBackgroundTaskWithExpirationHandler:)] &&
@@ -887,6 +888,7 @@ static Mixpanel *sharedInstance = nil;
 
 - (void)applicationWillTerminate:(NSNotification *)notification
 {
+    NSLog(@"applicationWillTerminate");
     MixpanelDebug(@"%@ application will terminate", self);
     @synchronized(self) {
         [self archive];


### PR DESCRIPTION
you must to archive when going to background for applications that support background execution.

From docs:
- (void)applicationWillTerminate:(UIApplication *)application

For applications that do not support background execution or are linked against iOS 3.x or earlier, this method is always called when the user quits the application. For applications that support background execution, this method is generally not called when the user quits the application because the application simply moves to the background in that case. However, this method may be called in situations where the application is running in the background (not suspended) and the system needs to terminate it for some reason.

After calling this method, the application also posts a UIApplicationWillTerminateNotification notification to give interested objects a chance to respond to the transition.
