### PR TITLE
Changed `id` return type to `instancetype`

### DIFF
--- a/Mixpanel/Mixpanel.h
+++ b/Mixpanel/Mixpanel.h
@@ -169,7 +169,7 @@
  
  @param apiToken        your project token
  */
-+ (id)sharedInstanceWithToken:(NSString *)apiToken;
++ (instancetype)sharedInstanceWithToken:(NSString *)apiToken;
 
 /*!
  @method
@@ -181,7 +181,7 @@
  The API must be initialized with <code>sharedInstanceWithToken:</code> before
  calling this class method.
  */
-+ (id)sharedInstance;
++ (instancetype)sharedInstance;
 
 /*!
  @method

--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -346,7 +346,7 @@ static Mixpanel *sharedInstance = nil;
 
 #pragma mark * Initializiation
 
-+ (id)sharedInstanceWithToken:(NSString *)apiToken
++ (instancetype)sharedInstanceWithToken:(NSString *)apiToken
 {
     @synchronized(self) {
         if (sharedInstance == nil) {
@@ -356,7 +356,7 @@ static Mixpanel *sharedInstance = nil;
     }
 }
 
-+ (id)sharedInstance
++ (instancetype)sharedInstance
 {
     @synchronized(self) {
         if (sharedInstance == nil) {


### PR DESCRIPTION
I changed the return type of the class constructors from `id` to `instancetype`. This enables you to track events without creating a `mixpanel` instance variable.

So, instead of using:

```
Mixpanel *mixpanel = [Mixpanel sharedInstance];
[mixpanel track:@"Clicked Button"];
```

You can save a line and use: 

```
[[Mixpanel sharedInstance] track:@"Clicked Button"];
```
