### PR TITLE
Added ability to remove previously registered super properties

### DIFF
--- a/Mixpanel/Mixpanel.h
+++ b/Mixpanel/Mixpanel.h
@@ -293,6 +293,48 @@
  @method
 
  @abstract
+ Removes previously registered super properties and discards the existing
+ values.
+
+ @discussion
+ As an alternative to clearing all properties, unregistering specific super
+ properties prevents them from being recorded on future events. This operation
+ does not affect the value of other super properties. Any property name that is
+ not registered is ignored.
+ 
+ Note that after removing a super property, events will show the attribute as 
+ having the value <code>undefined</code> in Mixpanel until a new value is
+ registered.
+
+ @param propertyNames   array of property name strings to remove
+ */
+- (void)removeSuperPropertiesNamed:(NSArray *)propertyNames;
+
+/*!
+ @method
+
+ @abstract
+ Removes a previously registered super property and discards the existing
+ value.
+
+ @discussion
+ As an alternative to clearing all properties, unregistering specific super
+ properties prevents them from being recorded on future events. This operation
+ does not affect the value of other super properties. If a property by that name
+ is not registered, no changes are made.
+
+ Note that after removing a super property, events will show the attribute as
+ having the value <code>undefined</code> in Mixpanel until a new value is
+ registered.
+
+ @param propertyName    name of the property to remove
+ */
+- (void)removeSuperPropertyNamed:(NSString *)propertyName;
+
+/*!
+ @method
+
+ @abstract
  Returns the currently set super properties.
  */
 - (NSDictionary *)currentSuperProperties;

--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -496,6 +496,29 @@ static Mixpanel *sharedInstance = nil;
     }
 }
 
+- (void)removeSuperPropertiesNamed:(NSArray *)propertyNames
+{
+   @synchronized(self) {
+      [self.superProperties removeObjectsForKeys:propertyNames];
+      if ([Mixpanel inBackground]) {
+         [self archiveProperties];
+      }
+   }
+}
+
+- (void)removeSuperPropertyNamed:(NSString *)propertyName
+{
+   @synchronized(self) {
+      if ([self.superProperties objectForKey:propertyName] != nil)
+      {
+         [self.superProperties removeObjectForKey:propertyName];
+         if ([Mixpanel inBackground]) {
+            [self archiveProperties];
+         }
+      }
+   }
+}
+
 - (NSDictionary *)currentSuperProperties
 {
     @synchronized(self) {


### PR DESCRIPTION
Added methods to remove super properties that have been previously registered, for use as an alternative to clearing all of the super properties just to change a subset of them.

This is a refresh of #15 with proper synchronization and documentation. In our use case, it is far more efficient to remove specific super properties than to clear and rebuild the entire structure. Documentation reminds the user that no longer having a value for a property will cause it to be displayed as _undefined_ in Mixpanel.

The _remove_ verb was chosen rather than _unregister_, which is used in the Android API. This choice was for consistency with Cocoa collection methods and also because some people would expect _deregister_ rather than _unregister_. Glad to update the PR for consistency with Android if that is preferable.
