### PR TITLE
Changing Version and Bundle keys to better fit Xcode paradigm

### DIFF
--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -1049,7 +1049,8 @@ static Mixpanel *sharedInstance = nil;
     NSMutableDictionary *properties = [NSMutableDictionary dictionary];
     [properties setValue:[Mixpanel deviceModel] forKey:@"$ios_device_model"];
     [properties setValue:[device systemVersion] forKey:@"$ios_version"];
-    [properties setValue:[[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleVersion"] forKey:@"$ios_app_version"];
+    [properties setValue:[[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"] forKey:@"$ios_app_version"];
+    [properties setValue:[[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleVersion"] forKey:@"$ios_app_build"];
     return [NSDictionary dictionaryWithDictionary:properties];
 }
 


### PR DESCRIPTION
Changed CFBundleVersion to refer to $ios_app_build and added CFBundleShortVersionString to refer to $ios_app_version, as discussed in this Stack Overflow answer:

http://stackoverflow.com/questions/6851660/version-vs-build-in-xcode-4

Note: this pull request requires another special mixpanel attribute: $ios_app_build to refer to the build number.  
