### PR TITLE
fix missing default people distinctId

### DIFF
--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -134,6 +134,7 @@ static Mixpanel *sharedInstance = nil;
         self.showNetworkActivityIndicator = YES;
         self.serverURL = @"https://api.mixpanel.com";
         self.distinctId = [self defaultDistinctId];
+        self.people.distinctId = self.distinctId;
         self.superProperties = [NSMutableDictionary dictionary];
         self.automaticProperties = [self collectAutomaticProperties];
         self.eventsQueue = [NSMutableArray array];


### PR DESCRIPTION
distinctId was never set if Mixpanel's identify was never called, hence people's data was
never sent to the server with the right distinctId
