### PR TITLE
Fixes a crash due to mutating event or people data while archiving [regression]

### DIFF
--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -534,7 +534,7 @@ static Mixpanel *sharedInstance = nil;
         self.people.unidentifiedQueue = [NSMutableArray array];
         self.eventsQueue = [NSMutableArray array];
         self.peopleQueue = [NSMutableArray array];
-        [self archive];
+        [self archiveFromSerialQueue];
     });
 }
 
@@ -727,6 +727,14 @@ static Mixpanel *sharedInstance = nil;
 
 - (void)archive
 {
+   // Must archive from the serial queue to avoid conflicts from data mutation
+   dispatch_sync(self.serialQueue, ^{
+      [self archiveFromSerialQueue];
+   });
+}
+
+- (void)archiveFromSerialQueue
+{
     [self archiveEvents];
     [self archivePeople];
     [self archiveProperties];
@@ -866,7 +874,7 @@ static Mixpanel *sharedInstance = nil;
 {
     MixpanelDebug(@"%@ application will terminate", self);
     dispatch_async(self.serialQueue, ^{
-        [self archive];
+        [self archiveFromSerialQueue];
     });
 }
 


### PR DESCRIPTION
The `-archive` method can be used by an app to trigger an archive. However, the archive procedure is not dispatched to the serial queue, leaving any operations on the queue to mutate `eventsQueue` and `peopleQueue` while they are being archived. This causes the app to crash, a regression of #39 that was fixed last year before refactoring of the serialization. The crash appears to be quite rare at least in our circumstances, but we have seen it pop up on several occasions in our App Store releases.

One solution was to add an internal method for archiving from the serial queue and use that instead of `-archive`. This leaves `-archive` to be used solely by the app, so we can safely dispatch the event to the serial queue. Please advise whether you would prefer this to be dispatched asynchronously with `dispatch_async`, but it is my understanding that `dispatch_sync` would avoid changing the behavior of this method from sync to async.

Please cherry-pick this change into the people-identify branch if accepted.
