### PR TITLE
Prevent multiple calls to -flush.

### DIFF
--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -584,6 +584,11 @@ static Mixpanel *sharedInstance = nil;
 - (void)flush
 {
     dispatch_async(self.serialQueue, ^{
+        if (self.taskId != UIBackgroundTaskInvalid) {
+            MixpanelDebug(@"%@ flush already in progress", self);
+            return;
+        }
+
         if ([self.delegate respondsToSelector:@selector(mixpanelWillFlush:)]) {
             if (![self.delegate mixpanelWillFlush:self]) {
                 MixpanelDebug(@"%@ flush deferred by delegate", self);


### PR DESCRIPTION
Flushes are performed as background tasks, but since the task ID
is stored as an instance variable, calling -flush twice in a row
obliterates the first task ID and allows only the second one to
be ended correctly. This results in iOS killing your application
because a background task has been running for too long.
