### PR TITLE
Copy properties before heading off into the background in case the passed in dictionary is mutable.

### DIFF
--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -499,8 +499,8 @@ static Mixpanel *sharedInstance = nil;
 
 - (void)registerSuperProperties:(NSDictionary *)properties
 {
-    [Mixpanel assertPropertyTypes:properties];
     properties = [[properties copy] autorelease];
+    [Mixpanel assertPropertyTypes:properties];
     dispatch_async(self.serialQueue, ^{
         NSMutableDictionary *tmp = [NSMutableDictionary dictionaryWithDictionary:self.superProperties];
         [tmp addEntriesFromDictionary:properties];
@@ -513,8 +513,8 @@ static Mixpanel *sharedInstance = nil;
 
 - (void)registerSuperPropertiesOnce:(NSDictionary *)properties
 {
-    [Mixpanel assertPropertyTypes:properties];
     properties = [[properties copy] autorelease];
+    [Mixpanel assertPropertyTypes:properties];
     dispatch_async(self.serialQueue, ^{
         NSMutableDictionary *tmp = [NSMutableDictionary dictionaryWithDictionary:self.superProperties];
         for (NSString *key in properties) {
@@ -531,8 +531,8 @@ static Mixpanel *sharedInstance = nil;
 
 - (void)registerSuperPropertiesOnce:(NSDictionary *)properties defaultValue:(id)defaultValue
 {
-    [Mixpanel assertPropertyTypes:properties];
     properties = [[properties copy] autorelease];
+    [Mixpanel assertPropertyTypes:properties];
     dispatch_async(self.serialQueue, ^{
         NSMutableDictionary *tmp = [NSMutableDictionary dictionaryWithDictionary:self.superProperties];
         for (NSString *key in properties) {


### PR DESCRIPTION
If you tell Mixpanel to track an event with a properties dictionary that is mutable, Mixpanel will take it into a background thread, and as a result it's possible to get a crash on "collection was mutated while being enumerated".  (`NSMutableDictionary` objects are not threadsafe)

Calling `copy` on an immutable dictionary simply sends it a `retain` message, so the performance overhead is negligible in most situations.  
