### PR TITLE
MP Survey QuestionVC: Remove iOS 7 only warning

### DIFF
--- a/Mixpanel/MPSurveyQuestionViewController.m
+++ b/Mixpanel/MPSurveyQuestionViewController.m
@@ -90,9 +90,14 @@ typedef NS_ENUM(NSInteger, MPSurveyTableViewCellPosition) {
                                                     attributes:@{NSFontAttributeName: font}
                                                        context:nil].size;
         } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
+
             sizeToFit = [_prompt.text sizeWithFont:font
                                  constrainedToSize:constraintSize
                                      lineBreakMode:_prompt.lineBreakMode];
+
+#pragma clang diagnostic pop
         }
 
         if (sizeToFit.height <= promptHeight) {


### PR DESCRIPTION
Ignoring deprecated methods for iOS 7.
