### PR TITLE
Request surveys by People distinctId rather than Event distinctId

### DIFF
--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -949,7 +949,7 @@ static Mixpanel *sharedInstance = nil;
 
             MixpanelDebug(@"%@ survey cache not found, starting network request", self);
 
-            NSString *params = [NSString stringWithFormat:@"version=1&lib=iphone&token=%@&distinct_id=%@", self.apiToken, MPURLEncode(self.distinctId)];
+            NSString *params = [NSString stringWithFormat:@"version=1&lib=iphone&token=%@&distinct_id=%@", self.apiToken, MPURLEncode(self.people.distinctId)];
             NSURL *url = [NSURL URLWithString:[self.serverURL stringByAppendingString:[NSString stringWithFormat:@"/decide?%@", params]]];
             NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
             [request setValue:@"gzip" forHTTPHeaderField:@"Accept-Encoding"];


### PR DESCRIPTION
Surveys must be requested by People ID, rather than Events ID in case the two happen to be different. This will not affect most people but we are still stuck using a separate identifier for people and events until Mixpanel resolves the inability to `alias` multiple "device IDs" to the same "user ID."

This is a simple, straightforward change. The preceding lines already use `self.people.distinctId` to ensure that an identifier is set, and in all normal use of the library these identifiers will be equivalent. The problem in our case was that the event identifier `self.distinctId` was being sent to the survey endpoint, causing the following error to be emitted:

```
survey check api error: distinct_id, no user found
```

This change simply sends `self.people.distinctId` rather than `self.distinctId` in that request.
