### PR TITLE
Date formatting bug on Japanese / Thailand environment

### DIFF
--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -150,6 +150,9 @@ static Mixpanel *sharedInstance = nil;
         self.dateFormatter = [[NSDateFormatter alloc] init];
         [_dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"];
         [_dateFormatter setTimeZone:[NSTimeZone timeZoneWithAbbreviation:@"UTC"]];
+        NSCalendar *calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
+        [_dateFormatter setCalendar:calendar];
+        [_dateFormatter setLocale:[[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"]];
 
         self.showSurveyOnActive = YES;
         self.checkForSurveysOnActive = YES;


### PR DESCRIPTION
When enable "12-Hours display (Japanese)" or using "Japanese Calender" or using "Buddhist Calender",
The time/date are not sent definitely.
