### PR TITLE
Allow developer to disable location tracking

### DIFF
--- a/Mixpanel/Mixpanel.h
+++ b/Mixpanel/Mixpanel.h
@@ -84,6 +84,18 @@
 
 /*!
  @property
+ 
+ @abstract
+ Control whether MixPanel will record the user's approximate
+ location based on their IP address
+ 
+ @discussion
+ Defaults to YES.
+ */
+@property (atomic) BOOL trackLocation;
+
+/*!
+ @property
 
  @abstract
  Flush timer's interval.

--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -138,6 +138,7 @@ static Mixpanel *sharedInstance = nil;
         self.people = [[MixpanelPeople alloc] initWithMixpanel:self];
         self.apiToken = apiToken;
         _flushInterval = flushInterval;
+        self.trackLocation = YES;
         self.flushOnBackground = YES;
         self.showNetworkActivityIndicator = YES;
 
@@ -756,7 +757,7 @@ static Mixpanel *sharedInstance = nil;
         NSArray *batch = [queue subarrayWithRange:NSMakeRange(0, batchSize)];
 
         NSString *requestData = [self encodeAPIData:batch];
-        NSString *postBody = [NSString stringWithFormat:@"ip=1&data=%@", requestData];
+        NSString *postBody = [NSString stringWithFormat:@"ip=%d&data=%@", self.trackLocation ? 1 : 0, requestData];
         MixpanelDebug(@"%@ flushing %lu of %lu to %@: %@", self, (unsigned long)[batch count], (unsigned long)[queue count], endpoint, queue);
         NSURLRequest *request = [self apiRequestWithEndpoint:endpoint andBody:postBody];
         NSError *error = nil;


### PR DESCRIPTION
MixPanel collects the user's approximate location data based on IP
address; this change allows the developer to opt out of this data
collection.