### PR TITLE
fixed build warning: initialization of 'NSData *' to null from boolean expression

### DIFF
--- a/Mixpanel/MPNotification.m
+++ b/Mixpanel/MPNotification.m
@@ -149,7 +149,7 @@ NSString *const MPNotificationTypeTakeover = @"takeover";
         NSData *imageData = [NSData dataWithContentsOfURL:_imageURL options:NSDataReadingMappedIfSafe error:&error];
         if (error || !imageData) {
             NSLog(@"image failed to load from URL: %@", _imageURL);
-            return NO;
+            return nil;
         }
         _image = imageData;
     }


### PR DESCRIPTION
When archiving my application with mix panel, i get the warning:

Mixpanel/MPNotification.m:152:20: Initialization of pointer of type 'NSData *' to null from a constant boolean expression

Simple fix to remove the warning.
