### PR TITLE
Suppress unused variable warning in MPObjectSerializer.m

### DIFF
--- a/Mixpanel/MPObjectSerializer.m
+++ b/Mixpanel/MPObjectSerializer.m
@@ -166,7 +166,7 @@
 
 - (NSInvocation *)invocationForObject:(id)object withSelectorDescription:(MPPropertySelectorDescription *)selectorDescription
 {
-    NSUInteger parameterCount = [selectorDescription.parameters count];
+    NSUInteger __unused parameterCount = [selectorDescription.parameters count];
 
     SEL aSelector = NSSelectorFromString(selectorDescription.selectorName);
     NSAssert(aSelector != nil, @"Expected non-nil selector!");


### PR DESCRIPTION
The `parameterCount` variable in `invocationForObject: withSelectorDescription:` is only referenced in a (run-time) call to NSAssert -- so XCode throws a warning that the variable is unused.

This PR adds an __unused flag to the variable to suppress that false warning
