### PR TITLE
support the lack of a distinct_id on people...

### DIFF
--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -968,7 +968,7 @@ static Mixpanel *sharedInstance = nil;
     MixpanelDebug(@"%@ application did become active", self);
     [self startFlushTimer];
 
-    if (self.checkForSurveysOnActive || self.checkForNotificationsOnActive) {
+    if (self.checkForSurveysOnActive || self.checkForNotificationsOnActive || self.checkForVariantsOnActive) {
         NSDate *start = [NSDate date];
 
         [self checkForDecideResponseWithCompletion:^(NSArray *surveys, NSArray *notifications, NSSet *variants) {


### PR DESCRIPTION
.. by defaulting to other distinct_id
- fall back to events distinct_id when making decide request if
  there is no people profile distinct id
- do not merge experiment_id and variant_id into the $experiments
  property if there is no people profile
