### PR TITLE
Fix imports to be able to build static library and generate Xamarin bindings

### DIFF
--- a/Mixpanel/MPABTestDesignerSnapshotResponseMessage.h
+++ b/Mixpanel/MPABTestDesignerSnapshotResponseMessage.h
@@ -2,6 +2,7 @@
 // Copyright (c) 2014 Mixpanel. All rights reserved.
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 #import "MPAbstractABTestDesignerMessage.h"
 
 @interface MPABTestDesignerSnapshotResponseMessage : MPAbstractABTestDesignerMessage

--- a/Mixpanel/MPApplicationStateSerializer.h
+++ b/Mixpanel/MPApplicationStateSerializer.h
@@ -2,6 +2,7 @@
 // Copyright (c) 2014 Mixpanel. All rights reserved.
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 @class MPObjectSerializerConfig;
 @class MPObjectIdentityProvider;

--- a/Mixpanel/MPApplicationStateSerializer.m
+++ b/Mixpanel/MPApplicationStateSerializer.m
@@ -1,6 +1,7 @@
 //
 // Copyright (c) 2014 Mixpanel. All rights reserved.
 
+#import <UIKit/UIKit.h>
 #import <QuartzCore/QuartzCore.h>
 #import "MPApplicationStateSerializer.h"
 #import "MPClassDescription.h"

--- a/Mixpanel/MPCATransform3DToNSDictionaryValueTransformer.m
+++ b/Mixpanel/MPCATransform3DToNSDictionaryValueTransformer.m
@@ -1,6 +1,7 @@
 //
 // Copyright (c) 2014 Mixpanel. All rights reserved.
 
+#import <UIKit/UIKit.h>
 #import "MPValueTransformers.h"
 
 static NSDictionary *MPCATransform3DCreateDictionaryRepresentation(CATransform3D transform)

--- a/Mixpanel/MPCGAffineTransformToNSDictionaryValueTransformer.m
+++ b/Mixpanel/MPCGAffineTransformToNSDictionaryValueTransformer.m
@@ -1,6 +1,7 @@
 //
 // Copyright (c) 2014 Mixpanel. All rights reserved.
 
+#import <UIKit/UIKit.h>
 #import "MPValueTransformers.h"
 
 static NSDictionary *MPCGAffineTransformCreateDictionaryRepresentation(CGAffineTransform transform)

--- a/Mixpanel/MPCGColorRefToNSStringValueTransformer.m
+++ b/Mixpanel/MPCGColorRefToNSStringValueTransformer.m
@@ -1,6 +1,7 @@
 //
 // Copyright (c) 2014 Mixpanel. All rights reserved.
 
+#import <UIKit/UIKit.h>
 #import "MPValueTransformers.h"
 
 @implementation MPCGColorRefToNSStringValueTransformer

--- a/Mixpanel/MPCGPointToNSDictionaryValueTransformer.m
+++ b/Mixpanel/MPCGPointToNSDictionaryValueTransformer.m
@@ -1,6 +1,7 @@
 //
 // Copyright (c) 2014 Mixpanel. All rights reserved.
 
+#import <UIKit/UIKit.h>
 #import "MPValueTransformers.h"
 
 @implementation MPCGPointToNSDictionaryValueTransformer

--- a/Mixpanel/MPCGRectToNSDictionaryValueTransformer.m
+++ b/Mixpanel/MPCGRectToNSDictionaryValueTransformer.m
@@ -1,6 +1,8 @@
 //
 // Copyright (c) 2014 Mixpanel. All rights reserved.
 
+#import <UIKit/UIKit.h>
+#import <CoreGraphics/CoreGraphics.h>
 #import "MPValueTransformers.h"
 
 @implementation MPCGRectToNSDictionaryValueTransformer

--- a/Mixpanel/MPCGSizeToNSDictionaryValueTransformer.m
+++ b/Mixpanel/MPCGSizeToNSDictionaryValueTransformer.m
@@ -1,6 +1,7 @@
 //
 // Copyright (c) 2014 Mixpanel. All rights reserved.
 
+#import <UIKit/UIKit.h>
 #import "MPValueTransformers.h"
 
 @implementation MPCGSizeToNSDictionaryValueTransformer

--- a/Mixpanel/MPLogger.h
+++ b/Mixpanel/MPLogger.h
@@ -9,6 +9,8 @@
 #ifndef MPLogger_h
 #define MPLogger_h
 
+#import <Foundation/Foundation.h>
+
 static inline void MPLog(NSString *format, ...) {
     __block va_list arg_list;
     va_start (arg_list, format);

--- a/Mixpanel/MPNSAttributedStringToNSDictionaryValueTransformer.m
+++ b/Mixpanel/MPNSAttributedStringToNSDictionaryValueTransformer.m
@@ -1,6 +1,7 @@
 //
 // Copyright (c) 2014 Mixpanel. All rights reserved.
 
+#import <UIKit/UIKit.h>
 #import "MPLogger.h"
 #import "MPValueTransformers.h"
 

--- a/Mixpanel/MPNSNumberToCGFloatValueTransformer.m
+++ b/Mixpanel/MPNSNumberToCGFloatValueTransformer.m
@@ -1,6 +1,7 @@
 //
 // Copyright (c) 2014 Mixpanel. All rights reserved.
 
+#import <CoreGraphics/CoreGraphics.h>
 #import "MPValueTransformers.h"
 
 @implementation MPNSNumberToCGFloatValueTransformer

--- a/Mixpanel/MPNotification.h
+++ b/Mixpanel/MPNotification.h
@@ -1,4 +1,5 @@
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 @interface MPNotification : NSObject
 

--- a/Mixpanel/MPNotificationViewController.h
+++ b/Mixpanel/MPNotificationViewController.h
@@ -2,6 +2,7 @@
 #error This file must be compiled with ARC. Either turn on ARC for the project or use -fobjc-arc flag on this file.
 #endif
 
+#import <UIKit/UIKit.h>
 #import "MPNotification.h"
 
 @protocol MPNotificationViewControllerDelegate;

--- a/Mixpanel/MPObjectSelector.m
+++ b/Mixpanel/MPObjectSelector.m
@@ -7,6 +7,7 @@
 //
 
 #import <objc/runtime.h>
+#import <UIKit/UIKit.h>
 #import "MPObjectSelector.h"
 #import "NSData+MPBase64.h"
 

--- a/Mixpanel/MPUIColorToNSStringValueTransformer.m
+++ b/Mixpanel/MPUIColorToNSStringValueTransformer.m
@@ -1,6 +1,7 @@
 //
 // Copyright (c) 2014 Mixpanel. All rights reserved.
 
+#import <UIKit/UIKit.h>
 #import "MPValueTransformers.h"
 
 @implementation MPUIColorToNSStringValueTransformer

--- a/Mixpanel/MPUIControlBinding.h
+++ b/Mixpanel/MPUIControlBinding.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2014 Mixpanel. All rights reserved.
 //
 
+#import <UIKit/UIKit.h>
 #import "MPEventBinding.h"
 
 @interface MPUIControlBinding : MPEventBinding

--- a/Mixpanel/MPUIEdgeInsetsToNSDictionaryValueTransformer.m
+++ b/Mixpanel/MPUIEdgeInsetsToNSDictionaryValueTransformer.m
@@ -1,6 +1,7 @@
 //
 // Copyright (c) 2014 Mixpanel. All rights reserved.
 
+#import <UIKit/UIKit.h>
 #import "MPValueTransformers.h"
 
 @implementation MPUIEdgeInsetsToNSDictionaryValueTransformer

--- a/Mixpanel/MPUIFontToNSDictionaryValueTransformer.m
+++ b/Mixpanel/MPUIFontToNSDictionaryValueTransformer.m
@@ -1,6 +1,7 @@
 //
 // Copyright (c) 2014 Mixpanel. All rights reserved.
 
+#import <UIKit/UIKit.h>
 #import "MPValueTransformers.h"
 
 @implementation MPUIFontToNSDictionaryValueTransformer

--- a/Mixpanel/MPUIImageToNSDictionaryValueTransformer.m
+++ b/Mixpanel/MPUIImageToNSDictionaryValueTransformer.m
@@ -1,6 +1,7 @@
 //
 // Copyright (c) 2014 Mixpanel. All rights reserved.
 
+#import <UIKit/UIKit.h>
 #import <ImageIO/ImageIO.h>
 #import "MPValueTransformers.h"
 #import "NSData+MPBase64.h"

--- a/Mixpanel/MPUITableViewBinding.m
+++ b/Mixpanel/MPUITableViewBinding.m
@@ -7,6 +7,7 @@
 //
 
 #import <objc/runtime.h>
+#import <UIKit/UIKit.h>
 #import "MPSwizzler.h"
 #import "MPUITableViewBinding.h"
 

--- a/Mixpanel/MPValueTransformers.h
+++ b/Mixpanel/MPValueTransformers.h
@@ -1,6 +1,8 @@
 //
 // Copyright (c) 2014 Mixpanel. All rights reserved.
 
+#import <Foundation/Foundation.h>
+
 @interface MPPassThroughValueTransformer : NSValueTransformer
 
 @end

--- a/Mixpanel/MPVariant.m
+++ b/Mixpanel/MPVariant.m
@@ -6,6 +6,7 @@
 //  Copyright (c) 2014 Mixpanel. All rights reserved.
 //
 
+#import <UIKit/UIKit.h>
 #import "MPLogger.h"
 #import "MPObjectSelector.h"
 #import "MPSwizzler.h"

--- a/Mixpanel/NSInvocation+MPHelpers.m
+++ b/Mixpanel/NSInvocation+MPHelpers.m
@@ -2,6 +2,7 @@
 // Copyright (c) 2014 Mixpanel. All rights reserved.
 
 #import <objc/runtime.h>
+#import <CoreGraphics/CoreGraphics.h>
 #import "MPLogger.h"
 #import "NSInvocation+MPHelpers.h"
 

--- a/Mixpanel/UIImage+MPImageEffects.h
+++ b/Mixpanel/UIImage+MPImageEffects.h
@@ -93,6 +93,9 @@
  5/3/2013
  */
 
+#import <UIKit/UIKit.h>
+#import <CoreGraphics/CoreGraphics.h>
+
 @interface UIImage (MPImageEffects)
 
 - (UIImage *)mp_applyLightEffect;


### PR DESCRIPTION
Hi Mixpanel team!

Thanks for a clean and simple API! I have created bindings for Xamarin.iOS, in another repository. There were some problems building a static library from this code base, so attached are those changes that I had to make for it to work. Would of course like them to be included so the Xamarin bindings can easily follow updates from upstream.

Regards,
Andreas