### PR TITLE
Cut down console spam

### DIFF
--- a/Mixpanel/MPWebSocket.m
+++ b/Mixpanel/MPWebSocket.m
@@ -456,7 +456,7 @@ static __strong NSData *CRLFCRLF;
     NSInteger responseCode = CFHTTPMessageGetResponseStatusCode(_receivedHTTPHeaders);
 
     if (responseCode >= 400) {
-        MPLog(@"Request failed with response code %d", responseCode);
+        MixpanelError(@"Request failed with response code %d", responseCode);
         [self _failWithError:[NSError errorWithDomain:MPWebSocketErrorDomain code:2132 userInfo:[NSDictionary dictionaryWithObject:[NSString stringWithFormat:@"received bad response code from server %ld", (long)responseCode] forKey:NSLocalizedDescriptionKey]]];
         return;
 
@@ -502,7 +502,7 @@ static __strong NSData *CRLFCRLF;
         CFHTTPMessageAppendBytes(websocket->_receivedHTTPHeaders, (const UInt8 *)data.bytes, (CFIndex)data.length);
 
         if (CFHTTPMessageIsHeaderComplete(websocket->_receivedHTTPHeaders)) {
-            MPLog(@"Finished reading headers %@", CFBridgingRelease(CFHTTPMessageCopyAllHeaderFields(websocket->_receivedHTTPHeaders)));
+            MixpanelDebug(@"Finished reading headers %@", CFBridgingRelease(CFHTTPMessageCopyAllHeaderFields(websocket->_receivedHTTPHeaders)));
             [websocket _HTTPHeadersDidFinish];
         } else {
             [websocket _readHTTPHeader];
@@ -512,7 +512,7 @@ static __strong NSData *CRLFCRLF;
 
 - (void)didConnect
 {
-    MPLog(@"Connected");
+    MixpanelDebug(@"Connected");
     CFHTTPMessageRef request = CFHTTPMessageCreateRequest(NULL, CFSTR("GET"), (__bridge CFURLRef)_url, kCFHTTPVersion1_1);
 
     // Set host first so it defaults
@@ -634,7 +634,7 @@ static __strong NSData *CRLFCRLF;
 
         self.readyState = MPWebSocketStateClosing;
 
-        MPLog(@"Closing with code %d reason %@", code, reason);
+        MixpanelDebug(@"Closing with code %d reason %@", code, reason);
 
         if (wasConnecting) {
             [self _disconnect];
@@ -692,7 +692,7 @@ static __strong NSData *CRLFCRLF;
             self.readyState = MPWebSocketStateClosed;
             self->_selfRetain = nil;
 
-            MPLog(@"Failing with error %@", error.localizedDescription);
+            MixpanelError(@"Failing with error %@", error.localizedDescription);
 
             [self _disconnect];
         }
@@ -745,7 +745,7 @@ static __strong NSData *CRLFCRLF;
 
 - (void)_handleMessage:(id)message
 {
-    MPLog(@"Received message");
+    MixpanelDebug(@"Received message");
     [self _performDelegateBlock:^{
         [self.delegate webSocket:self didReceiveMessage:message];
     }];
@@ -791,7 +791,7 @@ static inline BOOL closeCodeIsValid(int closeCode) {
     size_t dataSize = data.length;
     __block uint16_t closeCode = 0;
 
-    MPLog(@"Received close frame");
+    MixpanelDebug(@"Received close frame");
 
     if (dataSize == 1) {
         // TODO handle error
@@ -828,7 +828,7 @@ static inline BOOL closeCodeIsValid(int closeCode) {
 - (void)_disconnect;
 {
     [self assertOnWorkQueue];
-    MPLog(@"Trying to disconnect");
+    MixpanelDebug(@"Trying to disconnect");
     _closeWhenFinishedWriting = YES;
     [self _pumpWriting];
 }
@@ -1428,7 +1428,7 @@ static const size_t MPFrameHeaderOverhead = 32;
 
             case NSStreamEventEndEncountered: {
                 [self _pumpScanner];
-                MPLog(@"NSStreamEventEndEncountered %@", aStream);
+                MixpanelDebug(@"NSStreamEventEndEncountered %@", aStream);
                 if (aStream.streamError) {
                     [self _failWithError:aStream.streamError];
                 } else {
@@ -1452,7 +1452,7 @@ static const size_t MPFrameHeaderOverhead = 32;
             }
 
             case NSStreamEventHasBytesAvailable: {
-                MPLog(@"NSStreamEventHasBytesAvailable %@", aStream);
+                MixpanelDebug(@"NSStreamEventHasBytesAvailable %@", aStream);
                 const int bufferSize = 2048;
                 uint8_t buffer[bufferSize];
 
@@ -1474,13 +1474,13 @@ static const size_t MPFrameHeaderOverhead = 32;
             }
 
             case NSStreamEventHasSpaceAvailable: {
-                MPLog(@"NSStreamEventHasSpaceAvailable %@", aStream);
+                MixpanelDebug(@"NSStreamEventHasSpaceAvailable %@", aStream);
                 [self _pumpWriting];
                 break;
             }
 
             default:
-                MPLog(@"(default)  %@", aStream);
+                MixpanelDebug(@"(default)  %@", aStream);
                 break;
         }
     });


### PR DESCRIPTION
It looks like some MPLog statements were left in the MPWebSocket class. I'm assuming they aren't supposed to be there. This PR changes them to MixpanelError and MixpanelDebug for errors and debug logs, respectively.

It's pretty annoying to have Mixpanel logs in my console when I'm trying to debug my app. 

Please let me know if I should change some of the MixpanelError macros over to MixpanelDebug. I'd be happy to do so.