### PR TITLE
Ignore stale snapshot messages

### DIFF
--- a/Mixpanel/MPABTestDesignerSnapshotRequestMessage.m
+++ b/Mixpanel/MPABTestDesignerSnapshotRequestMessage.m
@@ -45,9 +45,12 @@ static NSString * const kObjectIdentityProviderKey = @"object_identity_provider"
         // Update the class descriptions in the connection session if provided as part of the message.
         if (serializerConfig) {
             [connection setSessionObject:serializerConfig forKey:kSnapshotSerializerConfigKey];
-        } else {
+        } else if ([connection sessionObjectForKey:kSnapshotSerializerConfigKey]){
             // Get the class descriptions from the connection session store.
             serializerConfig = [connection sessionObjectForKey:kSnapshotSerializerConfigKey];
+        } else {
+            // If neither place has a config, this is probably a stale message and we can't create a snapshot.
+            return;
         }
 
         // Get the object identity provider from the connection's session store or create one if there is none already.


### PR DESCRIPTION
When the app is restarted in the simulator, and reconnects to the switchboard, there can be a queued snapshot request message that gets delivered to the device. This snapshot request doesn't contain the required snapshot configuration, and the app has lost its cached version as it's been restarted.