### PR TITLE
Remove warnings generated with XCode 6.3 iOS 8.3 SDK

### DIFF
--- a/Mixpanel.podspec
+++ b/Mixpanel.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'Mixpanel'
-  s.version      = '2.7.2'
+  s.version      = '2.7.3'
   s.summary      = 'iPhone tracking library for Mixpanel Analytics'
   s.homepage     = 'https://mixpanel.com'
   s.license      = 'Apache License, Version 2.0'

--- a/Mixpanel/MPSurveyNavigationController.m
+++ b/Mixpanel/MPSurveyNavigationController.m
@@ -16,7 +16,7 @@
 
 @interface MPSurveyNavigationController () <MPSurveyQuestionViewControllerDelegate>
 
-@property (nonatomic, strong) IBOutlet UIImageView *view;
+@property (nonatomic, strong, readonly) UIImageView *imageView;
 @property (nonatomic, strong) IBOutlet UIColor *highlightColor;
 @property (nonatomic, strong) IBOutlet UIView *containerView;
 @property (nonatomic, strong) IBOutlet UILabel *pageNumberLabel;
@@ -35,10 +35,18 @@
 @implementation MPSurveyNavigationController
 
 
+- (UIImageView *)imageView {
+  if ([self.view isKindOfClass:[UIImageView class]] || self.view == nil) {
+    return (UIImageView *)self.view;
+  }
+  MixpanelError(@"Expecting self.view to be a UIImageView! Got %@ instead", [self.view class]);
+  return nil;
+}
+
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-    self.view.image = [_backgroundImage mp_applyDarkEffect];
+    self.imageView.image = [_backgroundImage mp_applyDarkEffect];
 
     // set highlight color based on average background color
     UIColor *avgColor = [_backgroundImage mp_averageColor];

--- a/Mixpanel/MPSurveyQuestionViewController.m
+++ b/Mixpanel/MPSurveyQuestionViewController.m
@@ -15,7 +15,7 @@
 
 @interface MPSurveyMultipleChoiceQuestionViewController : MPSurveyQuestionViewController <UITableViewDataSource, UITableViewDelegate>
 
-@property (nonatomic, strong) MPSurveyMultipleChoiceQuestion *question;
+@property (nonatomic, strong, readonly) MPSurveyMultipleChoiceQuestion *multipleChoiceQuestion;
 @property (nonatomic, strong) IBOutlet UITableView *tableView;
 @property (nonatomic, strong) IBOutlet UIView *tableContainer;
 @property (nonatomic, strong) IBOutlet NSLayoutConstraint *tableContainerVerticalPadding;
@@ -52,7 +52,7 @@ typedef NS_ENUM(NSInteger, MPSurveyTableViewCellPosition) {
 
 @interface MPSurveyTextQuestionViewController : MPSurveyQuestionViewController <UITextViewDelegate>
 
-@property (nonatomic, strong) MPSurveyTextQuestion *question;
+@property (nonatomic, strong, readonly) MPSurveyTextQuestion *textQuestion;
 @property (nonatomic, strong) IBOutlet NSLayoutConstraint *promptTopSpace;
 @property (nonatomic, strong) IBOutlet UITextView *textView;
 @property (nonatomic, strong) IBOutlet NSLayoutConstraint *textViewHeight;
@@ -266,13 +266,13 @@ typedef NS_ENUM(NSInteger, MPSurveyTableViewCellPosition) {
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section
 {
-    return (NSInteger)[self.question.choices count];
+    return (NSInteger)[self.multipleChoiceQuestion.choices count];
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
 {
     MPSurveyTableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"MPSurveyTableViewCell"];
-    NSString *text = [self labelForValue:(self.question.choices)[(NSUInteger)indexPath.row]];
+    NSString *text = [self labelForValue:(self.multipleChoiceQuestion.choices)[(NSUInteger)indexPath.row]];
     cell.label.text = text;
     cell.selectedLabel.text = text;
     UIColor *strokeColor = [UIColor colorWithWhite:1 alpha:0.5];
@@ -283,12 +283,12 @@ typedef NS_ENUM(NSInteger, MPSurveyTableViewCellPosition) {
     cell.customSelectedBackgroundView.fillColor = [self.highlightColor colorWithAlphaComponent:0.3f];
     MPSurveyTableViewCellPosition position;
     if (indexPath.row == 0) {
-        if ([self.question.choices count] == 1) {
+        if ([self.multipleChoiceQuestion.choices count] == 1) {
             position = MPSurveyTableViewCellPositionSingle;
         } else {
             position = MPSurveyTableViewCellPositionTop;
         }
-    } else if (indexPath.row == (NSInteger)([self.question.choices count] - 1)) {
+    } else if (indexPath.row == (NSInteger)([self.multipleChoiceQuestion.choices count] - 1)) {
         position = MPSurveyTableViewCellPositionBottom;
     } else {
         position = MPSurveyTableViewCellPositionMiddle;
@@ -308,7 +308,7 @@ typedef NS_ENUM(NSInteger, MPSurveyTableViewCellPosition) {
     MPSurveyTableViewCell *cell = (MPSurveyTableViewCell *)[tableView cellForRowAtIndexPath:indexPath];
     if (!cell.isChecked) {
         [cell setChecked:YES animatedWithCompletion:^(BOOL finished){
-            id value = (self.question.choices)[(NSUInteger)indexPath.row];
+            id value = (self.multipleChoiceQuestion.choices)[(NSUInteger)indexPath.row];
             __strong id<MPSurveyQuestionViewControllerDelegate> strongDelegate = self.delegate;
             if (strongDelegate != nil) {
                 [strongDelegate questionController:self didReceiveAnswerProperties:@{@"$value": value}];
@@ -323,6 +323,15 @@ typedef NS_ENUM(NSInteger, MPSurveyTableViewCellPosition) {
     if (cell.isChecked) {
         [cell setChecked:NO animatedWithCompletion:nil];
     }
+}
+
+- (MPSurveyMultipleChoiceQuestion *)multipleChoiceQuestion {
+  if ([self.question isKindOfClass:[MPSurveyMultipleChoiceQuestion class]] ||
+      self.question == nil) {
+    return (MPSurveyMultipleChoiceQuestion *)self.question;
+  }
+  MixpanelError(@"%@ unexpected question. Expecting MC question, had %@", [self.question class]);
+  return nil;
 }
 
 @end
@@ -440,6 +449,15 @@ typedef NS_ENUM(NSInteger, MPSurveyTableViewCellPosition) {
 - (IBAction)hideKeyboard
 {
     [self.textView resignFirstResponder];
+}
+
+- (MPSurveyTextQuestion *)textQuestion {
+  if ([self.question isKindOfClass:[MPSurveyTextQuestion class]] ||
+      self.question == nil) {
+    return (MPSurveyTextQuestion *)self.question;
+  }
+  MixpanelError(@"%@ unexpected question. Expecting text question, had %@", [self.question class]);
+  return nil;
 }
 
 @end

--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -28,7 +28,7 @@
 #import "MPWebSocket.h"
 #import "NSData+MPBase64.h"
 
-#define VERSION @"2.7.2"
+#define VERSION @"2.7.3"
 
 @interface Mixpanel () <UIAlertViewDelegate, MPSurveyNavigationControllerDelegate, MPNotificationViewControllerDelegate> {
     NSUInteger _flushInterval;


### PR DESCRIPTION
- Rename overriding properties and create as readonly. Implement readonly property methods to check against the desired superclass property and return if appropriate.