### PR TITLE
Fix warnings from XCode 6.3 iOS 8.3 for overriding properties

### DIFF
--- a/Mixpanel/MPSurveyNavigationController.m
+++ b/Mixpanel/MPSurveyNavigationController.m
@@ -34,6 +34,8 @@
 
 @implementation MPSurveyNavigationController
 
+// Since view is declared as a different class in superclass UIViewController,
+// indicate dynamic to use parent accessors.
 @dynamic view;
 
 - (void)viewDidLoad

--- a/Mixpanel/MPSurveyQuestionViewController.m
+++ b/Mixpanel/MPSurveyQuestionViewController.m
@@ -221,6 +221,8 @@ typedef NS_ENUM(NSInteger, MPSurveyTableViewCellPosition) {
 
 @implementation MPSurveyMultipleChoiceQuestionViewController
 
+// Since question is declared as a different class in superclass MPSurveyQuestionViewController,
+// indicate dynamic to use parent accessors.
 @dynamic question;
 
 - (void)viewDidLoad
@@ -331,6 +333,8 @@ typedef NS_ENUM(NSInteger, MPSurveyTableViewCellPosition) {
 
 @implementation MPSurveyTextQuestionViewController
 
+// Since question is declared as a different class in superclass MPSurveyQuestionViewController,
+// indicate dynamic to use parent accessors.
 @dynamic question;
 
 - (void)viewDidLoad


### PR DESCRIPTION
"Auto property synthesis will not synthesize property 'view'; it will be implemented by its superclass, use @dynamic to acknowledge intention"