### PR TITLE
Making sure data is archived even if the host app has crashed

### DIFF
--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -36,7 +36,9 @@ static void mp_uncaughtExceptionHandler(NSException *exception) {
     for (Mixpanel *mixpanel in mp_mixpanelInstances) {
         [mixpanel archive];
     }
-    mp_originalExceptionHandler(exception);
+    if (mp_originalExceptionHandler) {
+        mp_originalExceptionHandler(exception);
+    }
 }
 
 @interface Mixpanel () <UIAlertViewDelegate, MPSurveyNavigationControllerDelegate, MPNotificationViewControllerDelegate> {
@@ -202,6 +204,8 @@ static Mixpanel *sharedInstance = nil;
         static dispatch_once_t onceToken;
         dispatch_once(&onceToken, ^{
             mp_mixpanelInstances = [NSHashTable weakObjectsHashTable];
+            mp_originalExceptionHandler = NSGetUncaughtExceptionHandler();
+            NSSetUncaughtExceptionHandler(&mp_uncaughtExceptionHandler);
         });
         [mp_mixpanelInstances addObject:self];
     }


### PR DESCRIPTION
Hi, we noticed that some of our users don't have any super-properties
After investigation, here is a scenario that caused the problem:
Host application crashes, mixpanel looses all the data since it keeps all the properties in memory in-between app being backgrounded / terminated.

A possible solution: not to remove the archived plist files after reading them on startup but it would only preserve last serialised state not the latest set one, which is not desirable when dealing with sensitive user data.

Proposed solution: become one of the chain of the exception handlers and archive data upon exception