### PR TITLE
Clear variants and shownNotifications variable in reset function

### DIFF
--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -537,6 +537,9 @@ static __unused NSString *MPURLEncode(NSString *s)
         self.eventsQueue = [NSMutableArray array];
         self.peopleQueue = [NSMutableArray array];
         self.timedEvents = [NSMutableDictionary dictionary];
+        self.variants = [NSSet set];
+        self.shownNotifications = [NSMutableSet set];
+        
         [self archive];
     });
 }


### PR DESCRIPTION
@alex-hofsteede 

In a kiosk situation, apps will call mixpanel.reset() at the end of every anonymous session. Currently, past variants are persisting through this reset. This is causing no new experiments to be displayed once one of each variant has been received. By including variants and shownNotifications in the reset we can allow AB tests to show the most recent variant that has been received from decide.