### PR TITLE
Possible fix for issue 261 and issue 234.

### DIFF
--- a/Mixpanel/MPLogger.h
+++ b/Mixpanel/MPLogger.h
@@ -11,6 +11,10 @@
 #ifndef MPLogger_h
 #define MPLogger_h
 
+#if DEBUG
+#define MIXPANEL_DEBUG
+#endif
+
 static inline void MPLog(NSString *format, ...) {
     __block va_list arg_list;
     va_start (arg_list, format);

--- a/Mixpanel/MPLogger.h
+++ b/Mixpanel/MPLogger.h
@@ -11,10 +11,6 @@
 #ifndef MPLogger_h
 #define MPLogger_h
 
-#if DEBUG
-#define MIXPANEL_DEBUG
-#endif
-
 static inline void MPLog(NSString *format, ...) {
     __block va_list arg_list;
     va_start (arg_list, format);


### PR DESCRIPTION
Basic changes:

1.  Consolidated the socket cleanup path so that each location does everything.

2.  Switched from using the self pointer (which might in weird circumstances get nil'ed out while the code is running) to using the queue itself in setspecific/getspecific in an attempt to fix https://github.com/mixpanel/mixpanel-iphone/issues/261.

3.  Significantly reduced the number of places where the self-referencing pointer is set to nil, to ensure that it doesn't happen until any code that depends on "self" has finished.

Thus far, with these changes, I haven't seen the weird crashes in https://github.com/mixpanel/mixpanel-iphone/issues/234 (_MPRunLoopThread main crash in CFSocketEnableCallBacks/_spin_lock).  However, the bug was nondeterministic, so this isn't guaranteed to fix the problem.