### PR TITLE
added support for the $ignore_time flag setting

### DIFF
--- a/Mixpanel/Mixpanel.h
+++ b/Mixpanel/Mixpanel.h
@@ -692,6 +692,21 @@
  People</b>.
  */
 @interface MixpanelPeople : NSObject
+/*!
+ @property
+ 
+ @abstract
+ controls the $ignore_time property in any subsequent MixpanelPeople operation.
+ 
+ If the $ignore_time property is present and true in your request,
+ Mixpanel will not automatically update the "Last Seen" property of the profile.
+ Otherwise, Mixpanel will add a "Last Seen" property associated with the
+ current time for all $set, $append, and $add operations
+ 
+ @discussion
+ Defaults to NO.
+ */
+@property (atomic) BOOL ignoreTime;
 
 /*!
  @method

--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -1839,10 +1839,12 @@ static void MixpanelReachabilityCallback(SCNetworkReachabilityRef target, SCNetw
 
 - (void)addPeopleRecordToQueueWithAction:(NSString *)action andProperties:(NSDictionary *)properties
 {
-    properties = [properties copy];
     NSNumber *epochMilliseconds = @(round([[NSDate date] timeIntervalSince1970] * 1000));
     __strong Mixpanel *strongMixpanel = _mixpanel;
     if (strongMixpanel) {
+        properties = [properties copy];
+        BOOL ignore_time = self.ignoreTime;
+
         dispatch_async(strongMixpanel.serialQueue, ^{
             NSMutableDictionary *r = [NSMutableDictionary dictionary];
             NSMutableDictionary *p = [NSMutableDictionary dictionary];
@@ -1850,6 +1852,9 @@ static void MixpanelReachabilityCallback(SCNetworkReachabilityRef target, SCNetw
             if (!r[@"$time"]) {
                 // milliseconds unix timestamp
                 r[@"$time"] = epochMilliseconds;
+            }
+            if (ignore_time) {
+                r[@"$ignore_time"] = @(true);
             }
             if ([action isEqualToString:@"$set"] || [action isEqualToString:@"$set_once"]) {
                 [p addEntriesFromDictionary:self.automaticPeopleProperties];

--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -1854,7 +1854,7 @@ static void MixpanelReachabilityCallback(SCNetworkReachabilityRef target, SCNetw
                 r[@"$time"] = epochMilliseconds;
             }
             if (ignore_time) {
-                r[@"$ignore_time"] = @(true);
+                r[@"$ignore_time"] = @YES;
             }
             if ([action isEqualToString:@"$set"] || [action isEqualToString:@"$set_once"]) {
                 [p addEntriesFromDictionary:self.automaticPeopleProperties];


### PR DESCRIPTION
I want to be able to set/increment properties without updating the "Last Seen" flag in the Profiles.  (Useful for tracking background tasks, like GeoFencing, etc).

