### PR TITLE
Automated conversion to modern syntax.

### DIFF
--- a/HelloMixpanel/ABTestingTests/ABTestingTests.m
+++ b/HelloMixpanel/ABTestingTests/ABTestingTests.m
@@ -53,7 +53,7 @@
 @end
 @implementation A
 
-- (id)init
+- (instancetype)init
 {
     if((self = [super init])) {
         self.count = 0;

--- a/HelloMixpanel/EventBindingTests/EventBindingTests.m
+++ b/HelloMixpanel/EventBindingTests/EventBindingTests.m
@@ -28,7 +28,7 @@
 
 @implementation MixpanelStub
 
-- (id)init
+- (instancetype)init
 {
     if (self = [super init]) {
         _calls = [NSMutableArray array];
@@ -60,7 +60,7 @@
 @end
 @implementation TableController
 
-- (id)init
+- (instancetype)init
 {
     if (self = [super init]) {
         self.tableView = [[UITableView alloc] initWithFrame:[[UIScreen mainScreen] applicationFrame] style:UITableViewStylePlain];
@@ -141,7 +141,7 @@
                                   @"event_type": @"ui_control",
                                   @"event_name": @"ui control",
                                   @"path": c1_path,
-                                  @"control_event": [NSNumber numberWithInt:64] // touchUpInside
+                                  @"control_event": @64 // touchUpInside
                                   };
 
 

--- a/HelloMixpanel/HelloMixpanel/SecretTableViewCell.m
+++ b/HelloMixpanel/HelloMixpanel/SecretTableViewCell.m
@@ -10,7 +10,7 @@
 
 @implementation SecretTableViewCell
 
-- (id)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier
+- (instancetype)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier
 {
     self = [super initWithStyle:style reuseIdentifier:reuseIdentifier];
     if (self) {

--- a/HelloMixpanel/HelloMixpanel/SomeTableViewController.m
+++ b/HelloMixpanel/HelloMixpanel/SomeTableViewController.m
@@ -36,7 +36,7 @@
     if (cell == nil) {
         cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:simpleTableIdentifier];
     }
-    cell.textLabel.text = [animals objectAtIndex:(unsigned)indexPath.row];
+    cell.textLabel.text = animals[(unsigned)indexPath.row];
 
     return cell;
 }

--- a/Mixpanel/MPABTestDesignerChangeRequestMessage.m
+++ b/Mixpanel/MPABTestDesignerChangeRequestMessage.m
@@ -28,9 +28,9 @@ NSString *const MPABTestDesignerChangeRequestMessageType = @"change_request";
             [connection setSessionObject:variant forKey:kSessionVariantKey];
         }
 
-        if ([[[self payload] objectForKey:@"actions"] isKindOfClass:[NSArray class]]) {
+        if ([[self payload][@"actions"] isKindOfClass:[NSArray class]]) {
             dispatch_sync(dispatch_get_main_queue(), ^{
-                [variant addActionsFromJSONObject:[[self payload] objectForKey:@"actions"] andExecute:YES];
+                [variant addActionsFromJSONObject:[self payload][@"actions"] andExecute:YES];
             });
         }
 

--- a/Mixpanel/MPABTestDesignerClearRequestMessage.m
+++ b/Mixpanel/MPABTestDesignerClearRequestMessage.m
@@ -28,7 +28,7 @@ NSString *const MPABTestDesignerClearRequestMessageType = @"clear_request";
 
         MPVariant *variant = [conn sessionObjectForKey:kSessionVariantKey];
         if (variant) {
-            NSArray *actions = [self.payload objectForKey:@"actions"];
+            NSArray *actions = (self.payload)[@"actions"];
             dispatch_sync(dispatch_get_main_queue(), ^{
                 for (NSString *name in actions) {
                     [variant removeActionWithName:name];

--- a/Mixpanel/MPABTestDesignerConnection.h
+++ b/Mixpanel/MPABTestDesignerConnection.h
@@ -13,8 +13,8 @@ extern NSString *const kSessionVariantKey;
 @property (nonatomic, readonly) BOOL connected;
 @property (nonatomic, assign) BOOL sessionEnded;
 
-- (id)initWithURL:(NSURL *)url;
-- (id)initWithURL:(NSURL *)url keepTrying:(BOOL)keepTrying connectCallback:(void (^)())connectCallback disconnectCallback:(void (^)())disconnectCallback;
+- (instancetype)initWithURL:(NSURL *)url;
+- (instancetype)initWithURL:(NSURL *)url keepTrying:(BOOL)keepTrying connectCallback:(void (^)())connectCallback disconnectCallback:(void (^)())disconnectCallback NS_DESIGNATED_INITIALIZER;
 
 - (void)setSessionObject:(id)object forKey:(NSString *)key;
 - (id)sessionObjectForKey:(NSString *)key;

--- a/Mixpanel/MPABTestDesignerConnection.m
+++ b/Mixpanel/MPABTestDesignerConnection.m
@@ -45,7 +45,7 @@ NSString * const kSessionVariantKey = @"session_variant";
     void (^_disconnectCallback)();
 }
 
-- (id)initWithURL:(NSURL *)url keepTrying:(BOOL)keepTrying connectCallback:(void (^)())connectCallback disconnectCallback:(void (^)())disconnectCallback
+- (instancetype)initWithURL:(NSURL *)url keepTrying:(BOOL)keepTrying connectCallback:(void (^)())connectCallback disconnectCallback:(void (^)())disconnectCallback
 {
     self = [super init];
     if (self) {
@@ -81,7 +81,7 @@ NSString * const kSessionVariantKey = @"session_variant";
     return self;
 }
 
-- (id)initWithURL:(NSURL *)url
+- (instancetype)initWithURL:(NSURL *)url
 {
     return [self initWithURL:url keepTrying:NO connectCallback:nil disconnectCallback:nil];
 }

--- a/Mixpanel/MPABTestDesignerTweakRequestMessage.m
+++ b/Mixpanel/MPABTestDesignerTweakRequestMessage.m
@@ -33,9 +33,9 @@ NSString *const MPABTestDesignerTweakRequestMessageType = @"tweak_request";
             [conn setSessionObject:variant forKey:kSessionVariantKey];
         }
 
-        if ([[[self payload] objectForKey:@"tweaks"] isKindOfClass:[NSArray class]]) {
+        if ([[self payload][@"tweaks"] isKindOfClass:[NSArray class]]) {
             dispatch_sync(dispatch_get_main_queue(), ^{
-                [variant addTweaksFromJSONObject:[[self payload] objectForKey:@"tweaks"] andExecute:YES];
+                [variant addTweaksFromJSONObject:[self payload][@"tweaks"] andExecute:YES];
             });
         }
 

--- a/Mixpanel/MPAbstractABTestDesignerMessage.h
+++ b/Mixpanel/MPAbstractABTestDesignerMessage.h
@@ -10,8 +10,8 @@
 
 + (instancetype)messageWithType:(NSString *)type payload:(NSDictionary *)payload;
 
-- (id)initWithType:(NSString *)type;
-- (id)initWithType:(NSString *)type payload:(NSDictionary *)payload;
+- (instancetype)initWithType:(NSString *)type;
+- (instancetype)initWithType:(NSString *)type payload:(NSDictionary *)payload NS_DESIGNATED_INITIALIZER;
 
 - (void)setPayloadObject:(id)object forKey:(NSString *)key;
 - (id)payloadObjectForKey:(NSString *)key;

--- a/Mixpanel/MPAbstractABTestDesignerMessage.m
+++ b/Mixpanel/MPAbstractABTestDesignerMessage.m
@@ -21,12 +21,12 @@
     return [[self alloc] initWithType:type payload:payload];
 }
 
-- (id)initWithType:(NSString *)type
+- (instancetype)initWithType:(NSString *)type
 {
     return [self initWithType:type payload:@{}];
 }
 
-- (id)initWithType:(NSString *)type payload:(NSDictionary *)payload
+- (instancetype)initWithType:(NSString *)type payload:(NSDictionary *)payload
 {
     self = [super init];
     if (self) {
@@ -39,12 +39,12 @@
 
 - (void)setPayloadObject:(id)object forKey:(NSString *)key
 {
-    [_payload setObject:object ?: [NSNull null] forKey:key];
+    _payload[key] = object ?: [NSNull null];
 }
 
 - (id)payloadObjectForKey:(NSString *)key
 {
-    id object = [_payload objectForKey:key];
+    id object = _payload[key];
     return [object isEqual:[NSNull null]] ? nil : object;
 }
 

--- a/Mixpanel/MPApplicationStateSerializer.h
+++ b/Mixpanel/MPApplicationStateSerializer.h
@@ -8,7 +8,7 @@
 
 @interface MPApplicationStateSerializer : NSObject
 
-- (id)initWithApplication:(UIApplication *)application configuration:(MPObjectSerializerConfig *)configuration objectIdentityProvider:(MPObjectIdentityProvider *)objectIdentityProvider;
+- (instancetype)initWithApplication:(UIApplication *)application configuration:(MPObjectSerializerConfig *)configuration objectIdentityProvider:(MPObjectIdentityProvider *)objectIdentityProvider NS_DESIGNATED_INITIALIZER;
 
 - (UIImage *)screenshotImageForWindowAtIndex:(NSUInteger)index;
 

--- a/Mixpanel/MPApplicationStateSerializer.m
+++ b/Mixpanel/MPApplicationStateSerializer.m
@@ -16,7 +16,7 @@
     UIApplication *_application;
 }
 
-- (id)initWithApplication:(UIApplication *)application configuration:(MPObjectSerializerConfig *)configuration objectIdentityProvider:(MPObjectIdentityProvider *)objectIdentityProvider
+- (instancetype)initWithApplication:(UIApplication *)application configuration:(MPObjectSerializerConfig *)configuration objectIdentityProvider:(MPObjectIdentityProvider *)objectIdentityProvider
 {
     NSParameterAssert(application != nil);
     NSParameterAssert(configuration != nil);

--- a/Mixpanel/MPClassDescription.h
+++ b/Mixpanel/MPClassDescription.h
@@ -10,7 +10,7 @@
 @property (nonatomic, readonly) NSArray *propertyDescriptions;
 @property (nonatomic, readonly) NSArray *delegateInfos;
 
-- (id)initWithSuperclassDescription:(MPClassDescription *)superclassDescription dictionary:(NSDictionary *)dictionary;
+- (instancetype)initWithSuperclassDescription:(MPClassDescription *)superclassDescription dictionary:(NSDictionary *)dictionary NS_DESIGNATED_INITIALIZER;
 
 - (BOOL)isDescriptionForKindOfClass:(Class)class;
 
@@ -20,6 +20,6 @@
 
 @property (nonatomic, readonly) NSString *selectorName;
 
-- (id)initWithDictionary:(NSDictionary *)dictionary;
+- (instancetype)initWithDictionary:(NSDictionary *)dictionary NS_DESIGNATED_INITIALIZER;
 
 @end

--- a/Mixpanel/MPClassDescription.m
+++ b/Mixpanel/MPClassDescription.m
@@ -6,7 +6,7 @@
 
 @implementation MPDelegateInfo
 
-- (id)initWithDictionary:(NSDictionary *)dictionary
+- (instancetype)initWithDictionary:(NSDictionary *)dictionary
 {
     if (self = [super init]) {
         _selectorName = dictionary[@"selector"];
@@ -23,7 +23,7 @@
     NSArray *_delegateInfos;
 }
 
-- (id)initWithSuperclassDescription:(MPClassDescription *)superclassDescription dictionary:(NSDictionary *)dictionary
+- (instancetype)initWithSuperclassDescription:(MPClassDescription *)superclassDescription dictionary:(NSDictionary *)dictionary
 {
     self = [super initWithDictionary:dictionary];
     if (self) {

--- a/Mixpanel/MPDesignerEventBindingRequestMesssage.m
+++ b/Mixpanel/MPDesignerEventBindingRequestMesssage.m
@@ -69,8 +69,8 @@ NSString *const MPDesignerEventBindingRequestMessageType = @"event_binding_reque
         MPABTestDesignerConnection *conn = weak_connection;
 
         dispatch_sync(dispatch_get_main_queue(), ^{
-            NSLog(@"Loading event bindings:\n%@",[[self payload] objectForKey:@"events"]);
-            NSArray *payload = [[self payload] objectForKey:@"events"];
+            NSLog(@"Loading event bindings:\n%@",[self payload][@"events"]);
+            NSArray *payload = [self payload][@"events"];
             MPEventBindingCollection *bindingCollection = [conn sessionObjectForKey:@"event_bindings"];
             if (!bindingCollection) {
                 bindingCollection = [[MPEventBindingCollection alloc] init];

--- a/Mixpanel/MPDesignerTrackMessage.m
+++ b/Mixpanel/MPDesignerTrackMessage.m
@@ -24,12 +24,12 @@
     return[[self alloc] initWithType:@"track_message" andPayload:payload];
 }
 
-- (id)initWithType:(NSString *)type
+- (instancetype)initWithType:(NSString *)type
 {
     return [self initWithType:type andPayload:@{}];
 }
 
-- (id)initWithType:(NSString *)type andPayload:(NSDictionary *)payload
+- (instancetype)initWithType:(NSString *)type andPayload:(NSDictionary *)payload
 {
     if (self = [super initWithType:type]) {
         _payload = payload;

--- a/Mixpanel/MPEnumDescription.m
+++ b/Mixpanel/MPEnumDescription.m
@@ -9,7 +9,7 @@
     NSMutableDictionary *_values;
 }
 
-- (id)initWithDictionary:(NSDictionary *)dictionary
+- (instancetype)initWithDictionary:(NSDictionary *)dictionary
 {
     NSParameterAssert(dictionary[@"flag_set"] != nil);
     NSParameterAssert(dictionary[@"base_type"] != nil);

--- a/Mixpanel/MPEventBinding.h
+++ b/Mixpanel/MPEventBinding.h
@@ -33,7 +33,7 @@
 + (id)bindngWithJSONObject:(id)object;
 
 - (instancetype)init __unavailable;
-- (id)initWithEventName:(NSString *)eventName onPath:(NSString *)path;
+- (instancetype)initWithEventName:(NSString *)eventName onPath:(NSString *)path NS_DESIGNATED_INITIALIZER;
 
 /*!
  Intercepts track calls and adds a property indicating the track event

--- a/Mixpanel/MPEventBinding.m
+++ b/Mixpanel/MPEventBinding.m
@@ -20,7 +20,7 @@
         return nil;
     }
 
-    NSString *bindingType = [object objectForKey:@"event_type"];
+    NSString *bindingType = object[@"event_type"];
     Class klass = [self subclassFromString:bindingType];
     return [klass bindngWithJSONObject:object];
 }
@@ -41,7 +41,7 @@
     [[Mixpanel sharedInstance] track:event properties:bindingProperties];
 }
 
-- (id)initWithEventName:(NSString *)eventName onPath:(NSString *)path
+- (instancetype)initWithEventName:(NSString *)eventName onPath:(NSString *)path
 {
     if (self = [super init]) {
         self.eventName = eventName;
@@ -82,7 +82,7 @@
 
 #pragma mark -- NSCoder
 
-- (id)initWithCoder:(NSCoder *)aDecoder
+- (instancetype)initWithCoder:(NSCoder *)aDecoder
 {
     NSString *path = [aDecoder decodeObjectForKey:@"path"];
     NSString *eventName = [aDecoder decodeObjectForKey:@"eventName"];
@@ -96,7 +96,7 @@
 
 - (void)encodeWithCoder:(NSCoder *)aCoder
 {
-    [aCoder encodeObject:[NSNumber numberWithUnsignedLong:_ID] forKey:@"ID"];
+    [aCoder encodeObject:@(_ID) forKey:@"ID"];
     [aCoder encodeObject:_name forKey:@"name"];
     [aCoder encodeObject:_path.string forKey:@"path"];
     [aCoder encodeObject:_eventName forKey:@"eventName"];

--- a/Mixpanel/MPNSNumberToCGFloatValueTransformer.m
+++ b/Mixpanel/MPNSNumberToCGFloatValueTransformer.m
@@ -23,9 +23,9 @@
         // if the number is not a cgfloat, cast it to a cgfloat
         if (strcmp([number objCType], (char *) @encode(CGFloat)) != 0) {
             if (strcmp((char *) @encode(CGFloat), (char *) @encode(double)) == 0) {
-                value = [NSNumber numberWithDouble:[number doubleValue]];
+                value = @([number doubleValue]);
             } else {
-                value = [NSNumber numberWithFloat:[number floatValue]];
+                value = @([number floatValue]);
             }
         }
 

--- a/Mixpanel/MPNotification.m
+++ b/Mixpanel/MPNotification.m
@@ -7,7 +7,7 @@
 
 @interface MPNotification ()
 
-- (id)initWithID:(NSUInteger)ID messageID:(NSUInteger)messageID type:(NSString *)type title:(NSString *)title body:(NSString *)body callToAction:(NSString *)callToAction callToActionURL:(NSURL *)callToActionURL imageURL:(NSURL *)imageURL;
+- (instancetype)initWithID:(NSUInteger)ID messageID:(NSUInteger)messageID type:(NSString *)type title:(NSString *)title body:(NSString *)body callToAction:(NSString *)callToAction callToActionURL:(NSURL *)callToActionURL imageURL:(NSURL *)imageURL;
 
 @end
 
@@ -105,7 +105,7 @@ NSString *const MPNotificationTypeTakeover = @"takeover";
         }
     }
 
-    NSArray *supportedOrientations = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"UISupportedInterfaceOrientations"];
+    NSArray *supportedOrientations = [[NSBundle mainBundle] infoDictionary][@"UISupportedInterfaceOrientations"];
     if (![supportedOrientations containsObject:@"UIInterfaceOrientationPortrait"] && [type isEqualToString:@"takeover"]) {
         MixpanelError(@"takeover notifications are not supported in landscape-only apps.");
         return nil;
@@ -121,7 +121,7 @@ NSString *const MPNotificationTypeTakeover = @"takeover";
                                       imageURL:imageURL];
 }
 
-- (id)initWithID:(NSUInteger)ID messageID:(NSUInteger)messageID type:(NSString *)type title:(NSString *)title body:(NSString *)body callToAction:(NSString *)callToAction callToActionURL:(NSURL *)callToActionURL imageURL:(NSURL *)imageURL
+- (instancetype)initWithID:(NSUInteger)ID messageID:(NSUInteger)messageID type:(NSString *)type title:(NSString *)title body:(NSString *)body callToAction:(NSString *)callToAction callToActionURL:(NSURL *)callToActionURL imageURL:(NSURL *)imageURL
 {
     if (self = [super init]) {
         BOOL valid = YES;

--- a/Mixpanel/MPNotificationViewController.m
+++ b/Mixpanel/MPNotificationViewController.m
@@ -23,7 +23,7 @@
 
 @interface ElasticEaseOutAnimation : CAKeyframeAnimation {}
 
-- (id)initWithStartValue:(CGRect)start endValue:(CGRect)end andDuration:(double)duration;
+- (instancetype)initWithStartValue:(CGRect)start endValue:(CGRect)end andDuration:(double)duration NS_DESIGNATED_INITIALIZER;
 
 @end
 
@@ -541,7 +541,7 @@
 
 @implementation MPAlphaMaskView
 
-- (id)initWithCoder:(NSCoder *)aDecoder
+- (instancetype)initWithCoder:(NSCoder *)aDecoder
 {
     if(self = [super initWithCoder:aDecoder]) {
         _maskLayer = [GradientMaskLayer layer];
@@ -563,7 +563,7 @@
 
 @implementation MPActionButton
 
-- (id)initWithCoder:(NSCoder *)aDecoder
+- (instancetype)initWithCoder:(NSCoder *)aDecoder
 {
     if (self = [super initWithCoder:aDecoder]) {
         self.layer.backgroundColor = [UIColor colorWithRed:43.0f/255.0f green:43.0f/255.0f blue:52.0f/255.0f alpha:1.0f].CGColor;
@@ -630,7 +630,7 @@
 
 @implementation CircleLayer
 
-+ (id)layer {
++ (instancetype)layer {
     CircleLayer *cl = (CircleLayer *)[super layer];
     cl.circlePadding = 2.5f;
     return cl;
@@ -700,7 +700,7 @@
 
 @implementation ElasticEaseOutAnimation
 
-- (id)initWithStartValue:(CGRect)start endValue:(CGRect)end andDuration:(double)duration
+- (instancetype)initWithStartValue:(CGRect)start endValue:(CGRect)end andDuration:(double)duration
 {
     if ((self = [super init])) {
         self.duration = duration;

--- a/Mixpanel/MPObjectIdentityProvider.m
+++ b/Mixpanel/MPObjectIdentityProvider.m
@@ -11,7 +11,7 @@
     MPSequenceGenerator *_sequenceGenerator;
 }
 
-- (id)init
+- (instancetype)init
 {
     self = [super init];
     if (self) {

--- a/Mixpanel/MPObjectSelector.h
+++ b/Mixpanel/MPObjectSelector.h
@@ -13,7 +13,7 @@
 @property (nonatomic, strong, readonly) NSString *string;
 
 + (MPObjectSelector *)objectSelectorWithString:(NSString *)string;
-- (id)initWithString:(NSString *)string;
+- (instancetype)initWithString:(NSString *)string NS_DESIGNATED_INITIALIZER;
 
 - (NSArray *)selectFromRoot:(id)root;
 - (NSArray *)fuzzySelectFromRoot:(id)root;

--- a/Mixpanel/MPObjectSelector.m
+++ b/Mixpanel/MPObjectSelector.m
@@ -48,7 +48,7 @@
     return [[MPObjectSelector alloc] initWithString:string];
 }
 
-- (id)initWithString:(NSString *)string
+- (instancetype)initWithString:(NSString *)string
 {
     if (self = [super init]) {
         _string = string;
@@ -164,7 +164,7 @@
             NSString *predicateFormat;
             NSInteger index = 0;
             if ([_scanner scanInteger:&index] && [_scanner scanCharactersFromSet:_predicateEndChar intoString:nil]) {
-                filter.index = [NSNumber numberWithUnsignedInteger:(NSUInteger)index];
+                filter.index = @((NSUInteger)index);
             } else {
                 [_scanner scanUpToCharactersFromSet:_predicateEndChar intoString:&predicateFormat];
                 @try {
@@ -206,7 +206,7 @@
 
 @implementation MPObjectFilter
 
-- (id)init
+- (instancetype)init
 {
     if((self = [super init])) {
         self.unique = NO;

--- a/Mixpanel/MPObjectSerializer.h
+++ b/Mixpanel/MPObjectSerializer.h
@@ -13,7 +13,7 @@
 /*!
  @param     An array of MPClassDescription instances.
  */
-- (id)initWithConfiguration:(MPObjectSerializerConfig *)configuration objectIdentityProvider:(MPObjectIdentityProvider *)objectIdentityProvider;
+- (instancetype)initWithConfiguration:(MPObjectSerializerConfig *)configuration objectIdentityProvider:(MPObjectIdentityProvider *)objectIdentityProvider NS_DESIGNATED_INITIALIZER;
 
 - (NSDictionary *)serializedObjectsWithRootObject:(id)rootObject;
 

--- a/Mixpanel/MPObjectSerializer.m
+++ b/Mixpanel/MPObjectSerializer.m
@@ -23,7 +23,7 @@
     MPObjectIdentityProvider *_objectIdentityProvider;
 }
 
-- (id)initWithConfiguration:(MPObjectSerializerConfig *)configuration objectIdentityProvider:(MPObjectIdentityProvider *)objectIdentityProvider
+- (instancetype)initWithConfiguration:(MPObjectSerializerConfig *)configuration objectIdentityProvider:(MPObjectIdentityProvider *)objectIdentityProvider
 {
     self = [super init];
     if (self) {
@@ -131,7 +131,7 @@
 
     // TODO: write an algorithm that generates all the variations of parameter combinations.
     if ([selectorDescription.parameters count] > 0) {
-        MPPropertySelectorParameterDescription *parameterDescription = [selectorDescription.parameters objectAtIndex:0];
+        MPPropertySelectorParameterDescription *parameterDescription = (selectorDescription.parameters)[0];
         for (id value in [self allValuesForType:parameterDescription.type]) {
             [variations addObject:@[ value ]];
         }

--- a/Mixpanel/MPObjectSerializerConfig.h
+++ b/Mixpanel/MPObjectSerializerConfig.h
@@ -13,7 +13,7 @@
 @property (nonatomic, readonly) NSArray *classDescriptions;
 @property (nonatomic, readonly) NSArray *enumDescriptions;
 
-- (id)initWithDictionary:(NSDictionary *)dictionary;
+- (instancetype)initWithDictionary:(NSDictionary *)dictionary NS_DESIGNATED_INITIALIZER;
 
 - (MPTypeDescription *)typeWithName:(NSString *)name;
 - (MPEnumDescription *)enumWithName:(NSString *)name;

--- a/Mixpanel/MPObjectSerializerConfig.m
+++ b/Mixpanel/MPObjectSerializerConfig.m
@@ -13,7 +13,7 @@
     NSDictionary *_enums;
 }
 
-- (id)initWithDictionary:(NSDictionary *)dictionary
+- (instancetype)initWithDictionary:(NSDictionary *)dictionary
 {
     self = [super init];
     if (self) {
@@ -24,13 +24,13 @@
             MPClassDescription *classDescription = [[MPClassDescription alloc] initWithSuperclassDescription:superclassDescription
                                                                                                   dictionary:d];
 
-            [classDescriptions setObject:classDescription forKey:classDescription.name];
+            classDescriptions[classDescription.name] = classDescription;
         }
 
         NSMutableDictionary *enumDescriptions = [[NSMutableDictionary alloc] init];
         for (NSDictionary *d in dictionary[@"enums"]) {
             MPEnumDescription *enumDescription = [[MPEnumDescription alloc] initWithDictionary:d];
-            [enumDescriptions setObject:enumDescription forKey:enumDescription.name];
+            enumDescriptions[enumDescription.name] = enumDescription;
         }
 
         _classes = [classDescriptions copy];

--- a/Mixpanel/MPObjectSerializerContext.h
+++ b/Mixpanel/MPObjectSerializerContext.h
@@ -5,7 +5,7 @@
 
 @interface MPObjectSerializerContext : NSObject
 
-- (id)initWithRootObject:(id)object;
+- (instancetype)initWithRootObject:(id)object NS_DESIGNATED_INITIALIZER;
 
 - (BOOL)hasUnvisitedObjects;
 

--- a/Mixpanel/MPObjectSerializerContext.m
+++ b/Mixpanel/MPObjectSerializerContext.m
@@ -11,7 +11,7 @@
     NSMutableDictionary *_serializedObjects;
 }
 
-- (id)initWithRootObject:(id)object
+- (instancetype)initWithRootObject:(id)object
 {
     self = [super init];
     if (self) {

--- a/Mixpanel/MPPropertyDescription.h
+++ b/Mixpanel/MPPropertyDescription.h
@@ -7,7 +7,7 @@
 
 @interface MPPropertySelectorParameterDescription : NSObject
 
-- (id)initWithDictionary:(NSDictionary *)dictionary;
+- (instancetype)initWithDictionary:(NSDictionary *)dictionary NS_DESIGNATED_INITIALIZER;
 @property (nonatomic, readonly) NSString *name;
 @property (nonatomic, readonly) NSString *type;
 
@@ -15,7 +15,7 @@
 
 @interface MPPropertySelectorDescription : NSObject
 
-- (id)initWithDictionary:(NSDictionary *)dictionary;
+- (instancetype)initWithDictionary:(NSDictionary *)dictionary NS_DESIGNATED_INITIALIZER;
 @property (nonatomic, readonly) NSString *selectorName;
 @property (nonatomic, readonly) NSString *returnType;
 @property (nonatomic, readonly) NSArray *parameters; // array of MPPropertySelectorParameterDescription
@@ -24,7 +24,7 @@
 
 @interface MPPropertyDescription : NSObject
 
-- (id)initWithDictionary:(NSDictionary *)dictionary;
+- (instancetype)initWithDictionary:(NSDictionary *)dictionary NS_DESIGNATED_INITIALIZER;
 
 @property (nonatomic, readonly) NSString *type;
 @property (nonatomic, readonly) BOOL readonly;

--- a/Mixpanel/MPPropertyDescription.m
+++ b/Mixpanel/MPPropertyDescription.m
@@ -5,7 +5,7 @@
 
 @implementation MPPropertySelectorParameterDescription
 
-- (id)initWithDictionary:(NSDictionary *)dictionary
+- (instancetype)initWithDictionary:(NSDictionary *)dictionary
 {
     NSParameterAssert(dictionary[@"name"] != nil);
     NSParameterAssert(dictionary[@"type"] != nil);
@@ -23,7 +23,7 @@
 
 @implementation MPPropertySelectorDescription
 
-- (id)initWithDictionary:(NSDictionary *)dictionary
+- (instancetype)initWithDictionary:(NSDictionary *)dictionary
 {
     NSParameterAssert(dictionary[@"selector"] != nil);
     NSParameterAssert(dictionary[@"parameters"] != nil);
@@ -69,7 +69,7 @@
     return [NSValueTransformer valueTransformerForName:@"MPPassThroughValueTransformer"];
 }
 
-- (id)initWithDictionary:(NSDictionary *)dictionary
+- (instancetype)initWithDictionary:(NSDictionary *)dictionary
 {
     NSParameterAssert(dictionary[@"name"] != nil);
 

--- a/Mixpanel/MPSequenceGenerator.m
+++ b/Mixpanel/MPSequenceGenerator.m
@@ -10,12 +10,12 @@
     int32_t _value;
 }
 
-- (id)init
+- (instancetype)init
 {
     return [self initWithInitialValue:0];
 }
 
-- (id)initWithInitialValue:(int32_t)initialValue
+- (instancetype)initWithInitialValue:(int32_t)initialValue
 {
     self = [super init];
     if (self) {

--- a/Mixpanel/MPSurvey.m
+++ b/Mixpanel/MPSurvey.m
@@ -13,7 +13,7 @@
 @property (nonatomic) NSUInteger collectionID;
 @property (nonatomic, strong) NSArray *questions;
 
-- (id)initWithID:(NSUInteger)ID name:(NSString *)name collectionID:(NSUInteger)collectionID andQuestions:(NSArray *)questions;
+- (instancetype)initWithID:(NSUInteger)ID name:(NSString *)name collectionID:(NSUInteger)collectionID andQuestions:(NSArray *)questions;
 
 @end
 
@@ -63,7 +63,7 @@
                             andQuestions:[NSArray arrayWithArray:questions]];
 }
 
-- (id)initWithID:(NSUInteger)ID name:(NSString *)name collectionID:(NSUInteger)collectionID andQuestions:(NSArray *)questions
+- (instancetype)initWithID:(NSUInteger)ID name:(NSString *)name collectionID:(NSUInteger)collectionID andQuestions:(NSArray *)questions
 {
     if (self = [super init]) {
         BOOL valid = YES;

--- a/Mixpanel/MPSurveyQuestion.m
+++ b/Mixpanel/MPSurveyQuestion.m
@@ -14,7 +14,7 @@ static NSString *MPSurveyQuestionTypeText = @"text";
 @property (nonatomic, strong) NSString *type;
 @property (nonatomic, strong) NSString *prompt;
 
-- (id)initWithID:(NSUInteger)ID type:(NSString *)type andPrompt:(NSString *)prompt;
+- (instancetype)initWithID:(NSUInteger)ID type:(NSString *)type andPrompt:(NSString *)prompt;
 
 @end
 
@@ -22,7 +22,7 @@ static NSString *MPSurveyQuestionTypeText = @"text";
 
 @property (nonatomic, strong) NSArray *choices;
 
-- (id)initWithID:(NSUInteger)ID type:(NSString *)type prompt:(NSString *)prompt andChoices:(NSArray *)choices;
+- (instancetype)initWithID:(NSUInteger)ID type:(NSString *)type prompt:(NSString *)prompt andChoices:(NSArray *)choices;
 
 @end
 
@@ -69,7 +69,7 @@ static NSString *MPSurveyQuestionTypeText = @"text";
     return nil;
 }
 
-- (id)initWithID:(NSUInteger)ID type:(NSString *)type andPrompt:(NSString *)prompt
+- (instancetype)initWithID:(NSUInteger)ID type:(NSString *)type andPrompt:(NSString *)prompt
 {
     if (self = [super init]) {
         BOOL valid = NO;
@@ -97,7 +97,7 @@ static NSString *MPSurveyQuestionTypeText = @"text";
 
 @implementation MPSurveyMultipleChoiceQuestion
 
-- (id)initWithID:(NSUInteger)ID type:(NSString *)type prompt:(NSString *)prompt andChoices:(NSArray *)choices
+- (instancetype)initWithID:(NSUInteger)ID type:(NSString *)type prompt:(NSString *)prompt andChoices:(NSArray *)choices
 {
     if (choices != nil && [choices count] > 0) {
         if (self = [super initWithID:ID type:type andPrompt:prompt]) {

--- a/Mixpanel/MPSwizzler.m
+++ b/Mixpanel/MPSwizzler.m
@@ -21,7 +21,7 @@
 @property (nonatomic, assign) uint numArgs;
 @property (nonatomic, copy) NSMapTable *blocks;
 
-- (id)initWithBlock:(swizzleBlock)aBlock
+- (instancetype)initWithBlock:(swizzleBlock)aBlock
               named:(NSString *)aName
            forClass:(Class)aClass
            selector:(SEL)aSelector
@@ -209,7 +209,7 @@ static void (*mp_swizzledMethods[MAX_ARGS - MIN_ARGS + 1])() = {mp_swizzledMetho
 
 @implementation MPSwizzle
 
-- (id)init
+- (instancetype)init
 {
     if ((self = [super init])) {
         self.blocks = [NSMapTable mapTableWithKeyOptions:(NSPointerFunctionsStrongMemory | NSPointerFunctionsObjectPersonality)
@@ -218,7 +218,7 @@ static void (*mp_swizzledMethods[MAX_ARGS - MIN_ARGS + 1])() = {mp_swizzledMetho
     return self;
 }
 
-- (id)initWithBlock:(swizzleBlock)aBlock
+- (instancetype)initWithBlock:(swizzleBlock)aBlock
               named:(NSString *)aName
            forClass:(Class)aClass
            selector:(SEL)aSelector

--- a/Mixpanel/MPTweak.h
+++ b/Mixpanel/MPTweak.h
@@ -28,7 +28,7 @@ typedef id MPTweakValue;
   @abstract Creates a new tweak model.
   @discussion This is the designated initializer.
  */
-- (instancetype)initWithName:(NSString *)name andEncoding:(NSString *)encoding;
+- (instancetype)initWithName:(NSString *)name andEncoding:(NSString *)encoding NS_DESIGNATED_INITIALIZER;
 
 /**
   @abstract This tweak's unique name.

--- a/Mixpanel/MPTweakInline.m
+++ b/Mixpanel/MPTweakInline.m
@@ -23,64 +23,64 @@ static MPTweak *_MPTweakCreateWithEntry(NSString *name, mp_tweak_entry *entry)
   if (strcmp(*entry->encoding, @encode(BOOL)) == 0) {
     tweak.defaultValue = @(*(BOOL *)entry->value);
   } else if (strcmp(*entry->encoding, @encode(float)) == 0) {
-    tweak.defaultValue = [NSNumber numberWithFloat:*(float *)entry->value];
+    tweak.defaultValue = @(*(float *)entry->value);
     if (entry->min != NULL && entry->max != NULL) {
-      tweak.minimumValue = [NSNumber numberWithFloat:*(float *)entry->min];
-      tweak.maximumValue = [NSNumber numberWithFloat:*(float *)entry->max];
+      tweak.minimumValue = @(*(float *)entry->min);
+      tweak.maximumValue = @(*(float *)entry->max);
     }
   } else if (strcmp(*entry->encoding, @encode(double)) == 0) {
-    tweak.defaultValue = [NSNumber numberWithDouble:*(double *)entry->value];
+    tweak.defaultValue = @(*(double *)entry->value);
     if (entry->min != NULL && entry->max != NULL) {
-      tweak.minimumValue = [NSNumber numberWithDouble:*(double *)entry->min];
-      tweak.maximumValue = [NSNumber numberWithDouble:*(double *)entry->max];
+      tweak.minimumValue = @(*(double *)entry->min);
+      tweak.maximumValue = @(*(double *)entry->max);
     }
   } else if (strcmp(*entry->encoding, @encode(short)) == 0) {
-      tweak.defaultValue = [NSNumber numberWithShort:*(short *)entry->value];
+      tweak.defaultValue = @(*(short *)entry->value);
       if (entry->min != NULL && entry->max != NULL) {
-          tweak.minimumValue = [NSNumber numberWithShort:*(short *)entry->min];
-          tweak.maximumValue = [NSNumber numberWithShort:*(short *)entry->max];
+          tweak.minimumValue = @(*(short *)entry->min);
+          tweak.maximumValue = @(*(short *)entry->max);
       }
   } else if (strcmp(*entry->encoding, @encode(unsigned short)) == 0) {
-      tweak.defaultValue = [NSNumber numberWithUnsignedShort:*(unsigned short int *)entry->value];
+      tweak.defaultValue = @(*(unsigned short int *)entry->value);
       if (entry->min != NULL && entry->max != NULL) {
-          tweak.minimumValue = [NSNumber numberWithUnsignedShort:*(unsigned short *)entry->min];
-          tweak.maximumValue = [NSNumber numberWithUnsignedShort:*(unsigned short *)entry->max];
+          tweak.minimumValue = @(*(unsigned short *)entry->min);
+          tweak.maximumValue = @(*(unsigned short *)entry->max);
       }
   } else if (strcmp(*entry->encoding, @encode(int)) == 0) {
-    tweak.defaultValue = [NSNumber numberWithInt:*(int *)entry->value];
+    tweak.defaultValue = @(*(int *)entry->value);
     if (entry->min != NULL && entry->max != NULL) {
-      tweak.minimumValue = [NSNumber numberWithInt:*(int *)entry->min];
-      tweak.maximumValue = [NSNumber numberWithInt:*(int *)entry->max];
+      tweak.minimumValue = @(*(int *)entry->min);
+      tweak.maximumValue = @(*(int *)entry->max);
     }
   } else if (strcmp(*entry->encoding, @encode(uint)) == 0) {
-    tweak.defaultValue = [NSNumber numberWithUnsignedInt:*(uint *)entry->value];
+    tweak.defaultValue = @(*(uint *)entry->value);
     if (entry->min != NULL && entry->max != NULL) {
-      tweak.minimumValue = [NSNumber numberWithUnsignedInt:*(uint *)entry->min];
-      tweak.maximumValue = [NSNumber numberWithUnsignedInt:*(uint *)entry->max];
+      tweak.minimumValue = @(*(uint *)entry->min);
+      tweak.maximumValue = @(*(uint *)entry->max);
     }
   } else if (strcmp(*entry->encoding, @encode(long)) == 0) {
-      tweak.defaultValue = [NSNumber numberWithLong:*(long *)entry->value];
+      tweak.defaultValue = @(*(long *)entry->value);
       if (entry->min != NULL && entry->max != NULL) {
-          tweak.minimumValue = [NSNumber numberWithLong:*(long *)entry->min];
-          tweak.maximumValue = [NSNumber numberWithLong:*(long *)entry->max];
+          tweak.minimumValue = @(*(long *)entry->min);
+          tweak.maximumValue = @(*(long *)entry->max);
       }
   } else if (strcmp(*entry->encoding, @encode(unsigned long)) == 0) {
-      tweak.defaultValue = [NSNumber numberWithUnsignedLong:*(unsigned long *)entry->value];
+      tweak.defaultValue = @(*(unsigned long *)entry->value);
       if (entry->min != NULL && entry->max != NULL) {
-          tweak.minimumValue = [NSNumber numberWithUnsignedLong:*(unsigned long *)entry->min];
-          tweak.maximumValue = [NSNumber numberWithUnsignedLong:*(unsigned long *)entry->max];
+          tweak.minimumValue = @(*(unsigned long *)entry->min);
+          tweak.maximumValue = @(*(unsigned long *)entry->max);
       }
   } else if (strcmp(*entry->encoding, @encode(long long)) == 0) {
-      tweak.defaultValue = [NSNumber numberWithLongLong:*(long long *)entry->value];
+      tweak.defaultValue = @(*(long long *)entry->value);
       if (entry->min != NULL && entry->max != NULL) {
-          tweak.minimumValue = [NSNumber numberWithLongLong:*(long long *)entry->min];
-          tweak.maximumValue = [NSNumber numberWithLongLong:*(long long *)entry->max];
+          tweak.minimumValue = @(*(long long *)entry->min);
+          tweak.maximumValue = @(*(long long *)entry->max);
       }
   } else if (strcmp(*entry->encoding, @encode(unsigned long long)) == 0) {
-      tweak.defaultValue = [NSNumber numberWithUnsignedLongLong:*(unsigned long long *)entry->value];
+      tweak.defaultValue = @(*(unsigned long long *)entry->value);
       if (entry->min != NULL && entry->max != NULL) {
-          tweak.minimumValue = [NSNumber numberWithUnsignedLongLong:*(unsigned long long *)entry->min];
-          tweak.maximumValue = [NSNumber numberWithUnsignedLongLong:*(unsigned long long *)entry->max];
+          tweak.minimumValue = @(*(unsigned long long *)entry->min);
+          tweak.maximumValue = @(*(unsigned long long *)entry->max);
       }
   } else if (*entry->encoding[0] == '[') {
     // Assume it's a C string.

--- a/Mixpanel/MPTweakStore.m
+++ b/Mixpanel/MPTweakStore.m
@@ -49,7 +49,7 @@
 
 - (void)addTweak:(MPTweak *)tweak
 {
-  [_namedTweaks setObject:tweak forKey:tweak.name];
+  _namedTweaks[tweak.name] = tweak;
   [_orderedTweaks addObject:tweak];
 }
 

--- a/Mixpanel/MPTypeDescription.h
+++ b/Mixpanel/MPTypeDescription.h
@@ -5,7 +5,7 @@
 
 @interface MPTypeDescription : NSObject
 
-- (id)initWithDictionary:(NSDictionary *)dictionary;
+- (instancetype)initWithDictionary:(NSDictionary *)dictionary NS_DESIGNATED_INITIALIZER;
 
 @property (nonatomic, readonly) NSString *name;
 

--- a/Mixpanel/MPTypeDescription.m
+++ b/Mixpanel/MPTypeDescription.m
@@ -5,7 +5,7 @@
 
 @implementation MPTypeDescription
 
-- (id)initWithDictionary:(NSDictionary *)dictionary
+- (instancetype)initWithDictionary:(NSDictionary *)dictionary
 {
     self = [super init];
     if (self) {

--- a/Mixpanel/MPUIControlBinding.h
+++ b/Mixpanel/MPUIControlBinding.h
@@ -15,9 +15,9 @@
 @property (nonatomic, readonly) UIControlEvents verifyEvent;
 
 - (instancetype)init __unavailable;
-- (id)initWithEventName:(NSString *)eventName
+- (instancetype)initWithEventName:(NSString *)eventName
                  onPath:(NSString *)path
        withControlEvent:(UIControlEvents)controlEvent
-         andVerifyEvent:(UIControlEvents)verifyEvent;
+         andVerifyEvent:(UIControlEvents)verifyEvent NS_DESIGNATED_INITIALIZER;
 
 @end

--- a/Mixpanel/MPUIControlBinding.m
+++ b/Mixpanel/MPUIControlBinding.m
@@ -34,13 +34,13 @@
 
 + (MPEventBinding *)bindngWithJSONObject:(NSDictionary *)object
 {
-    NSString *path = [object objectForKey:@"path"];
+    NSString *path = object[@"path"];
     if (![path isKindOfClass:[NSString class]] || [path length] < 1) {
         NSLog(@"must supply a view path to bind by");
         return nil;
     }
 
-    NSString *eventName = [object objectForKey:@"event_name"];
+    NSString *eventName = object[@"event_name"];
     if (![eventName isKindOfClass:[NSString class]] || [eventName length] < 1 ) {
         NSLog(@"binding requires an event name");
         return nil;
@@ -58,7 +58,7 @@
                                           andVerifyEvent:verifyEvent];
 }
 
-- (id)initWithEventName:(NSString *)eventName
+- (instancetype)initWithEventName:(NSString *)eventName
                  onPath:(NSString *)path
        withControlEvent:(UIControlEvents)controlEvent
          andVerifyEvent:(UIControlEvents)verifyEvent
@@ -217,11 +217,11 @@
 - (void)encodeWithCoder:(NSCoder *)aCoder
 {
     [super encodeWithCoder:aCoder];
-    [aCoder encodeObject:[NSNumber numberWithUnsignedInteger:_controlEvent] forKey:@"controlEvent"];
-    [aCoder encodeObject:[NSNumber numberWithUnsignedInteger:_verifyEvent] forKey:@"verifyEvent"];
+    [aCoder encodeObject:@(_controlEvent) forKey:@"controlEvent"];
+    [aCoder encodeObject:@(_verifyEvent) forKey:@"verifyEvent"];
 }
 
-- (id)initWithCoder:(NSCoder *)aDecoder
+- (instancetype)initWithCoder:(NSCoder *)aDecoder
 {
     if (self = [super initWithCoder:aDecoder]) {
         _controlEvent = [[aDecoder decodeObjectForKey:@"controlEvent"] unsignedIntegerValue];

--- a/Mixpanel/MPUIImageToNSDictionaryValueTransformer.m
+++ b/Mixpanel/MPUIImageToNSDictionaryValueTransformer.m
@@ -127,7 +127,7 @@ static NSMutableDictionary *imageCache;
         }
         else if ([images count] > 0)
         {
-            image = [images objectAtIndex:0];
+            image = images[0];
         }
 
         if (image && UIEdgeInsetsEqualToEdgeInsets(capInsets, UIEdgeInsetsZero) == NO) {

--- a/Mixpanel/MPUITableViewBinding.h
+++ b/Mixpanel/MPUITableViewBinding.h
@@ -11,6 +11,6 @@
 @interface MPUITableViewBinding : MPEventBinding
 
 - (instancetype)init __unavailable;
-- (instancetype)initWithEventName:(NSString *)eventName onPath:(NSString *)path withDelegate:(Class)delegateClass;
+- (instancetype)initWithEventName:(NSString *)eventName onPath:(NSString *)path withDelegate:(Class)delegateClass NS_DESIGNATED_INITIALIZER;
 
 @end

--- a/Mixpanel/MPUITableViewBinding.m
+++ b/Mixpanel/MPUITableViewBinding.m
@@ -20,13 +20,13 @@
 
 + (MPEventBinding *)bindngWithJSONObject:(NSDictionary *)object
 {
-    NSString *path = [object objectForKey:@"path"];
+    NSString *path = object[@"path"];
     if (![path isKindOfClass:[NSString class]] || [path length] < 1) {
         NSLog(@"must supply a view path to bind by");
         return nil;
     }
 
-    NSString *eventName = [object objectForKey:@"event_name"];
+    NSString *eventName = object[@"event_name"];
     if (![eventName isKindOfClass:[NSString class]] || [eventName length] < 1 ) {
         NSLog(@"binding requires an event name");
         return nil;
@@ -43,7 +43,7 @@
                                             withDelegate:tableDelegate];
 }
 
-- (id)initWithEventName:(NSString *)eventName onPath:(NSString *)path
+- (instancetype)initWithEventName:(NSString *)eventName onPath:(NSString *)path
 {
     return [self initWithEventName:eventName onPath:path withDelegate:nil];
 }

--- a/Mixpanel/MPVariant.m
+++ b/Mixpanel/MPVariant.m
@@ -38,7 +38,7 @@
 @property (nonatomic, copy) NSHashTable *appliedTo;
 
 + (MPVariantAction *)actionWithJSONObject:(NSDictionary *)object;
-- (id)initWithName:(NSString *)name
+- (instancetype)initWithName:(NSString *)name
                path:(MPObjectSelector *)path
            selector:(SEL)selector
                args:(NSArray *)args
@@ -62,7 +62,7 @@
 @property (nonatomic, strong) MPTweakValue value;
 
 + (MPVariantTweak *)tweakWithJSONObject:(NSDictionary *)object;
-- (id)initWithName:(NSString *)name
+- (instancetype)initWithName:(NSString *)name
           encoding:(NSString *)encoding
              value:(MPTweakValue)value;
 - (void)execute;
@@ -90,13 +90,13 @@
         return nil;
     }
 
-    NSArray *actions = [object objectForKey:@"actions"];
+    NSArray *actions = object[@"actions"];
     if (![actions isKindOfClass:[NSArray class]]) {
         MixpanelError(@"variant requires an array of actions");
         return nil;
     }
 
-    NSArray *tweaks = [object objectForKey:@"tweaks"];
+    NSArray *tweaks = object[@"tweaks"];
     if (![tweaks isKindOfClass:[NSArray class]]) {
         MixpanelError(@"variant requires an array of tweaks");
         return nil;
@@ -108,12 +108,12 @@
                                   tweaks:tweaks];
 }
 
-- (id)init
+- (instancetype)init
 {
     return [self initWithID:0 experimentID:0 actions:nil tweaks:nil];
 }
 
-- (id)initWithID:(NSUInteger)ID experimentID:(NSUInteger)experimentID actions:(NSArray *)actions tweaks:(NSArray *)tweaks
+- (instancetype)initWithID:(NSUInteger)ID experimentID:(NSUInteger)experimentID actions:(NSArray *)actions tweaks:(NSArray *)tweaks
 {
     if(self = [super init]) {
         self.ID = ID;
@@ -130,7 +130,7 @@
 
 #pragma mark NSCoding
 
-- (id)initWithCoder:(NSCoder *)aDecoder
+- (instancetype)initWithCoder:(NSCoder *)aDecoder
 {
     if (self = [super init]) {
         self.ID = [(NSNumber *)[aDecoder decodeObjectForKey:@"ID"] unsignedLongValue];
@@ -144,11 +144,11 @@
 
 - (void)encodeWithCoder:(NSCoder *)aCoder
 {
-    [aCoder encodeObject:[NSNumber numberWithUnsignedLong:_ID] forKey:@"ID"];
-    [aCoder encodeObject:[NSNumber numberWithUnsignedLong:_experimentID] forKey:@"experimentID"];
+    [aCoder encodeObject:@(_ID) forKey:@"ID"];
+    [aCoder encodeObject:@(_experimentID) forKey:@"experimentID"];
     [aCoder encodeObject:_actions forKey:@"actions"];
     [aCoder encodeObject:_tweaks forKey:@"tweaks"];
-    [aCoder encodeObject:[NSNumber numberWithBool:_finished] forKey:@"finished"];
+    [aCoder encodeObject:@(_finished) forKey:@"finished"];
 }
 
 #pragma mark Actions
@@ -333,13 +333,13 @@ static NSMapTable *originalCache;
                                  swizzleSelector:swizzleSelector];
 }
 
-- (id)init
+- (instancetype)init
 {
     [NSException raise:@"NotSupported" format:@"Please call initWithName: path: selector: args: original: swizzle: swizzleClass: swizzleSelector:"];
     return nil;
 }
 
-- (id)initWithName:(NSString *)name
+- (instancetype)initWithName:(NSString *)name
                path:(MPObjectSelector *)path
            selector:(SEL)selector
                args:(NSArray *)args
@@ -382,7 +382,7 @@ static NSMapTable *originalCache;
 
 #pragma mark NSCoding
 
-- (id)initWithCoder:(NSCoder *)aDecoder
+- (instancetype)initWithCoder:(NSCoder *)aDecoder
 {
     if (self = [super init]) {
         self.name = [aDecoder decodeObjectForKey:@"name"];
@@ -408,7 +408,7 @@ static NSMapTable *originalCache;
     [aCoder encodeObject:_args forKey:@"args"];
     [aCoder encodeObject:_original forKey:@"original"];
 
-    [aCoder encodeObject:[NSNumber numberWithBool:_swizzle] forKey:@"swizzle"];
+    [aCoder encodeObject:@(_swizzle) forKey:@"swizzle"];
     [aCoder encodeObject:NSStringFromClass(_swizzleClass) forKey:@"swizzleClass"];
     [aCoder encodeObject:NSStringFromSelector(_swizzleSelector) forKey:@"swizzleSelector"];
 }
@@ -555,7 +555,7 @@ static NSMapTable *originalCache;
                     [invocation setSelector:selector];
                     for (NSUInteger i = 0; i < requiredArgs; i++) {
 
-                        NSArray *argTuple = [args objectAtIndex:i];
+                        NSArray *argTuple = args[i];
                         id arg = transformValue(argTuple[0], argTuple[1]);
 
                         // Unpack NSValues to their base types.
@@ -645,14 +645,14 @@ static NSMapTable *originalCache;
                                           value:value];
 }
 
-- (id)init
+- (instancetype)init
 {
     [NSException raise:@"NotSupported" format:@"Please call initWithName:name encoding:encoding value:value"];
     return nil;
 
 }
 
-- (id)initWithName:(NSString *)name
+- (instancetype)initWithName:(NSString *)name
           encoding:(NSString *)encoding
              value:(MPTweakValue)value
 {
@@ -666,7 +666,7 @@ static NSMapTable *originalCache;
 
 #pragma mark NSCoding
 
-- (id)initWithCoder:(NSCoder *)aDecoder
+- (instancetype)initWithCoder:(NSCoder *)aDecoder
 {
     if (self = [super init]) {
         self.name = [aDecoder decodeObjectForKey:@"name"];

--- a/Mixpanel/MPWebSocket.h
+++ b/Mixpanel/MPWebSocket.h
@@ -20,12 +20,12 @@
 #import <Foundation/Foundation.h>
 #import <Security/SecCertificate.h>
 
-typedef enum {
+typedef NS_ENUM(unsigned int, MPWebSocketReadyState) {
     MPWebSocketStateConnecting = 0,
     MPWebSocketStateOpen = 1,
     MPWebSocketStateClosing = 2,
     MPWebSocketStateClosed = 3,
-} MPWebSocketReadyState;
+};
 
 @class MPWebSocket;
 
@@ -49,12 +49,12 @@ extern NSString *const MPWebSocketErrorDomain;
 @property (nonatomic, readonly, copy) NSString *protocol;
 
 // Protocols should be an array of strings that turn into Sec-WebSocket-Protocol.
-- (id)initWithURLRequest:(NSURLRequest *)request protocols:(NSArray *)protocols;
-- (id)initWithURLRequest:(NSURLRequest *)request;
+- (instancetype)initWithURLRequest:(NSURLRequest *)request protocols:(NSArray *)protocols NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithURLRequest:(NSURLRequest *)request;
 
 // Some helper constructors.
-- (id)initWithURL:(NSURL *)url protocols:(NSArray *)protocols;
-- (id)initWithURL:(NSURL *)url;
+- (instancetype)initWithURL:(NSURL *)url protocols:(NSArray *)protocols;
+- (instancetype)initWithURL:(NSURL *)url;
 
 // Delegate queue will be dispatch_main_queue by default.
 // You cannot set both OperationQueue and dispatch_queue.

--- a/Mixpanel/MPWebSocket.m
+++ b/Mixpanel/MPWebSocket.m
@@ -59,7 +59,7 @@
 #endif
 
 
-typedef enum  {
+typedef NS_OPTIONS(unsigned int, MPOpCode)  {
     MPOpCodeTextFrame = 0x1,
     MPOpCodeBinaryFrame = 0x2,
     // 3-7 reserved.
@@ -67,9 +67,9 @@ typedef enum  {
     MPOpCodePing = 0x9,
     MPOpCodePong = 0xA,
     // B-F reserved.
-} MPOpCode;
+};
 
-typedef enum {
+typedef NS_ENUM(unsigned int, MPStatusCode) {
     MPStatusCodeNormal = 1000,
     MPStatusCodeGoingAway = 1001,
     MPStatusCodeProtocolError = 1002,
@@ -80,7 +80,7 @@ typedef enum {
     MPStatusCodeInvalidUTF8 = 1007,
     MPStatusCodePolicyViolated = 1008,
     MPStatusCodeMessageTooBig = 1009,
-} MPStatusCode;
+};
 
 typedef struct {
     BOOL fin;
@@ -179,7 +179,7 @@ typedef void (^data_callback)(MPWebSocket *webSocket,  NSData *data);
 // This class is not thread-safe, and is expected to always be run on the same queue.
 @interface MPIOConsumerPool : NSObject
 
-- (id)initWithBufferCapacity:(NSUInteger)poolSize;
+- (instancetype)initWithBufferCapacity:(NSUInteger)poolSize NS_DESIGNATED_INITIALIZER;
 
 - (MPIOConsumer *)consumerWithScanner:(stream_scanner)scanner handler:(data_callback)handler bytesNeeded:(size_t)bytesNeeded readToCurrentFrame:(BOOL)readToCurrentFrame unmaskBytes:(BOOL)unmaskBytes;
 - (void)returnConsumer:(MPIOConsumer *)consumer;
@@ -293,7 +293,7 @@ static __strong NSData *CRLFCRLF;
     CRLFCRLF = [[NSData alloc] initWithBytes:"\r\n\r\n" length:4];
 }
 
-- (id)initWithURLRequest:(NSURLRequest *)request protocols:(NSArray *)protocols;
+- (instancetype)initWithURLRequest:(NSURLRequest *)request protocols:(NSArray *)protocols;
 {
     self = [super init];
     if (self) {
@@ -309,17 +309,17 @@ static __strong NSData *CRLFCRLF;
     return self;
 }
 
-- (id)initWithURLRequest:(NSURLRequest *)request;
+- (instancetype)initWithURLRequest:(NSURLRequest *)request;
 {
     return [self initWithURLRequest:request protocols:nil];
 }
 
-- (id)initWithURL:(NSURL *)url;
+- (instancetype)initWithURL:(NSURL *)url;
 {
     return [self initWithURL:url protocols:nil];
 }
 
-- (id)initWithURL:(NSURL *)url protocols:(NSArray *)protocols;
+- (instancetype)initWithURL:(NSURL *)url protocols:(NSArray *)protocols;
 {
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url];
     return [self initWithURLRequest:request protocols:protocols];
@@ -456,13 +456,13 @@ static __strong NSData *CRLFCRLF;
 
     if (responseCode >= 400) {
         MixpanelError(@"Request failed with response code %d", responseCode);
-        [self _failWithError:[NSError errorWithDomain:MPWebSocketErrorDomain code:2132 userInfo:[NSDictionary dictionaryWithObject:[NSString stringWithFormat:@"received bad response code from server %ld", (long)responseCode] forKey:NSLocalizedDescriptionKey]]];
+        [self _failWithError:[NSError errorWithDomain:MPWebSocketErrorDomain code:2132 userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat:@"received bad response code from server %ld", (long)responseCode]}]];
         return;
 
     }
 
     if(![self _checkHandshake:_receivedHTTPHeaders]) {
-        [self _failWithError:[NSError errorWithDomain:MPWebSocketErrorDomain code:2133 userInfo:[NSDictionary dictionaryWithObject:[NSString stringWithFormat:@"Invalid Sec-WebSocket-Accept response"] forKey:NSLocalizedDescriptionKey]]];
+        [self _failWithError:[NSError errorWithDomain:MPWebSocketErrorDomain code:2133 userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Invalid Sec-WebSocket-Accept response"]}]];
         return;
     }
 
@@ -470,7 +470,7 @@ static __strong NSData *CRLFCRLF;
     if (negotiatedProtocol) {
         // Make sure we requested the protocol
         if ([_requestedProtocols indexOfObject:negotiatedProtocol] == NSNotFound) {
-            [self _failWithError:[NSError errorWithDomain:MPWebSocketErrorDomain code:2133 userInfo:[NSDictionary dictionaryWithObject:[NSString stringWithFormat:@"Server specified Sec-WebSocket-Protocol that wasn't requested"] forKey:NSLocalizedDescriptionKey]]];
+            [self _failWithError:[NSError errorWithDomain:MPWebSocketErrorDomain code:2133 userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Server specified Sec-WebSocket-Protocol that wasn't requested"]}]];
             return;
         }
 
@@ -573,11 +573,11 @@ static __strong NSData *CRLFCRLF;
 
         // If we're using pinned certs, don't validate the certificate chain
         if ([_urlRequest mp_SSLPinnedCertificates].count) {
-            [SSLOptions setValue:[NSNumber numberWithBool:NO] forKey:(__bridge id)kCFStreamSSLValidatesCertificateChain];
+            [SSLOptions setValue:@NO forKey:(__bridge id)kCFStreamSSLValidatesCertificateChain];
         }
 
 #if DEBUG
-        [SSLOptions setValue:[NSNumber numberWithBool:NO] forKey:(__bridge id)kCFStreamSSLValidatesCertificateChain];
+        [SSLOptions setValue:@NO forKey:(__bridge id)kCFStreamSSLValidatesCertificateChain];
         MixpanelDebug(@"SocketRocket: In debug mode.  Allowing connection to any root cert");
 #endif
 
@@ -1067,7 +1067,7 @@ static const uint8_t MPPayloadLenMask   = 0x7F;
     if (dataLength - _outputBufferOffset > 0 && _outputStream.hasSpaceAvailable) {
         NSInteger bytesWritten = [_outputStream write:((const uint8_t *)_outputBuffer.bytes + _outputBufferOffset) maxLength:(dataLength - _outputBufferOffset)];
         if (bytesWritten == -1) {
-            [self _failWithError:[NSError errorWithDomain:MPWebSocketErrorDomain code:2145 userInfo:[NSDictionary dictionaryWithObject:@"Error writing to stream" forKey:NSLocalizedDescriptionKey]]];
+            [self _failWithError:[NSError errorWithDomain:MPWebSocketErrorDomain code:2145 userInfo:@{NSLocalizedDescriptionKey: @"Error writing to stream"}]];
              return;
         }
 
@@ -1091,7 +1091,7 @@ static const uint8_t MPPayloadLenMask   = 0x7F;
 
 
         for (NSArray *runLoop in [_scheduledRunloops copy]) {
-            [self unscheduleFromRunLoop:[runLoop objectAtIndex:0] forMode:[runLoop objectAtIndex:1]];
+            [self unscheduleFromRunLoop:runLoop[0] forMode:runLoop[1]];
         }
 
         if (!_failed) {
@@ -1180,7 +1180,7 @@ static const char CRLFCRLFBytes[] = {'\r', '\n', '\r', '\n'};
         return didWork;
     }
 
-    MPIOConsumer *consumer = [_consumers objectAtIndex:0];
+    MPIOConsumer *consumer = _consumers[0];
 
     size_t bytesNeeded = consumer.bytesNeeded;
 
@@ -1391,7 +1391,7 @@ static const size_t MPFrameHeaderOverhead = 32;
 
             if (!_pinnedCertFound) {
                 dispatch_async(_workQueue, ^{
-                    [self _failWithError:[NSError errorWithDomain:@"org.lolrus.SocketRocket" code:23556 userInfo:[NSDictionary dictionaryWithObject:[NSString stringWithFormat:@"Invalid server cert"] forKey:NSLocalizedDescriptionKey]]];
+                    [self _failWithError:[NSError errorWithDomain:@"org.lolrus.SocketRocket" code:23556 userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Invalid server cert"]}]];
                 });
                 return;
             }
@@ -1515,7 +1515,7 @@ static const size_t MPFrameHeaderOverhead = 32;
     NSMutableArray *_bufferedConsumers;
 }
 
-- (id)initWithBufferCapacity:(NSUInteger)poolSize;
+- (instancetype)initWithBufferCapacity:(NSUInteger)poolSize;
 {
     self = [super init];
     if (self) {
@@ -1525,7 +1525,7 @@ static const size_t MPFrameHeaderOverhead = 32;
     return self;
 }
 
-- (id)init
+- (instancetype)init
 {
     return [self initWithBufferCapacity:8];
 }
@@ -1692,7 +1692,7 @@ static NSRunLoop *networkRunLoop = nil;
     mp_dispatch_release(_waitGroup);
 }
 
-- (id)init
+- (instancetype)init
 {
     self = [super init];
     if (self) {

--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -92,7 +92,7 @@
 @property (nonatomic, copy) NSString *distinctId;
 @property (nonatomic, strong) NSDictionary *automaticPeopleProperties;
 
-- (id)initWithMixpanel:(Mixpanel *)mixpanel;
+- (instancetype)initWithMixpanel:(Mixpanel *)mixpanel;
 - (void)merge:(NSDictionary *)properties;
 
 @end
@@ -1807,7 +1807,7 @@ static void MixpanelReachabilityCallback(SCNetworkReachabilityRef target, SCNetw
 
 @implementation MixpanelPeople
 
-- (id)initWithMixpanel:(Mixpanel *)mixpanel
+- (instancetype)initWithMixpanel:(Mixpanel *)mixpanel
 {
     if (self = [self init]) {
         self.mixpanel = mixpanel;

--- a/Mixpanel/_MPTweakBindObserver.h
+++ b/Mixpanel/_MPTweakBindObserver.h
@@ -29,7 +29,7 @@ typedef void (^_MPTweakBindObserverBlock)(id object);
   @param block The block to call on change.
   @return A new bind observer.
 */
-- (instancetype)initWithTweak:(MPTweak *)tweak block:(_MPTweakBindObserverBlock)block;
+- (instancetype)initWithTweak:(MPTweak *)tweak block:(_MPTweakBindObserverBlock)block NS_DESIGNATED_INITIALIZER;
 
 /**
   @abstract Attaches to an object and deallocates with it.


### PR DESCRIPTION
This is an automated conversion performed by Xcode. This will ensure we're using `instancetype` instead of `id` where appropriate. It also makes use of the `NS_DESIGNATED_INITIALIZER` macro to increase clarity and aid interoperability with swift.