### PR TITLE
Fixing lack of firing flush timer in -initWithToken:launchOptions:andFlushInterval: method.

### DIFF
--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -135,7 +135,7 @@ static Mixpanel *sharedInstance = nil;
     if (self = [self init]) {
         self.people = [[MixpanelPeople alloc] initWithMixpanel:self];
         self.apiToken = apiToken;
-        _flushInterval = flushInterval;
+        self.flushInterval = flushInterval;
         self.flushOnBackground = YES;
         self.showNetworkActivityIndicator = YES;
 


### PR DESCRIPTION
Fix for issue https://github.com/mixpanel/mixpanel-iphone/issues/241