### PR TITLE
Notification/Survey Delegate Method

### DIFF
--- a/HelloMixpanel/HelloMixpanel.xcodeproj/project.pbxproj
+++ b/HelloMixpanel/HelloMixpanel.xcodeproj/project.pbxproj
@@ -95,6 +95,7 @@
 		86978874197466780095B277 /* MPNSNumberToCGFloatValueTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = 86978873197466780095B277 /* MPNSNumberToCGFloatValueTransformer.m */; };
 		86CC974E1811F82D0003EF50 /* MPNotification.m in Sources */ = {isa = PBXBuildFile; fileRef = 86CC974D1811F82D0003EF50 /* MPNotification.m */; };
 		86CC975018120A7E0003EF50 /* MPNotification.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 86CC974F18120A7E0003EF50 /* MPNotification.storyboard */; };
+		9344BEDD1B59C12B0068F2C6 /* MixpanelPresentationObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 9344BEDC1B59C12B0068F2C6 /* MixpanelPresentationObject.m */; };
 		A7B462D1191075DE00774977 /* MPApplicationStateSerializer.m in Sources */ = {isa = PBXBuildFile; fileRef = A7B462B5191075DE00774977 /* MPApplicationStateSerializer.m */; };
 		A7B462D2191075DE00774977 /* MPCATransform3DToNSDictionaryValueTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = A7B462B7191075DE00774977 /* MPCATransform3DToNSDictionaryValueTransformer.m */; };
 		A7B462D3191075DE00774977 /* MPCGAffineTransformToNSDictionaryValueTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = A7B462B9191075DE00774977 /* MPCGAffineTransformToNSDictionaryValueTransformer.m */; };
@@ -397,6 +398,8 @@
 		86CC974F18120A7E0003EF50 /* MPNotification.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = MPNotification.storyboard; sourceTree = "<group>"; };
 		87E586E7C287C284F35B10F1 /* Pods-HelloMixpanelTests.appstore.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HelloMixpanelTests.appstore.xcconfig"; path = "Pods/Target Support Files/Pods-HelloMixpanelTests/Pods-HelloMixpanelTests.appstore.xcconfig"; sourceTree = "<group>"; };
 		8FC963492975EFAFD23F9D96 /* Pods-HelloMixpanel.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HelloMixpanel.release.xcconfig"; path = "Pods/Target Support Files/Pods-HelloMixpanel/Pods-HelloMixpanel.release.xcconfig"; sourceTree = "<group>"; };
+		9344BEDB1B59C12B0068F2C6 /* MixpanelPresentationObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MixpanelPresentationObject.h; sourceTree = "<group>"; };
+		9344BEDC1B59C12B0068F2C6 /* MixpanelPresentationObject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MixpanelPresentationObject.m; sourceTree = "<group>"; };
 		A2497EBE08734F3183857AE1 /* libPods-HelloMixpanel.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-HelloMixpanel.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A7B462B4191075DE00774977 /* MPApplicationStateSerializer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = MPApplicationStateSerializer.h; sourceTree = "<group>"; };
 		A7B462B5191075DE00774977 /* MPApplicationStateSerializer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPApplicationStateSerializer.m; sourceTree = "<group>"; };
@@ -768,6 +771,8 @@
 				28FEFA0817CAE93200691355 /* UIImage+MPImageEffects.m */,
 				A7B462E81910898E00774977 /* WebSocket */,
 				184E4D1619A7D690003115CE /* MPDesignerSessionCollection.h */,
+				9344BEDB1B59C12B0068F2C6 /* MixpanelPresentationObject.h */,
+				9344BEDC1B59C12B0068F2C6 /* MixpanelPresentationObject.m */,
 			);
 			name = Mixpanel;
 			path = ../Mixpanel;
@@ -1382,6 +1387,7 @@
 				C38D5B875967DF2C2CF76158 /* MPABTestDesignerChangeRequestMessage.m in Sources */,
 				C38D5A25F71A31E130B264B4 /* MPABTestDesignerChangeResponseMessage.m in Sources */,
 				C38D5D9DCA172D6D7A02D1A4 /* MPABTestDesignerDeviceInfoRequestMessage.m in Sources */,
+				9344BEDD1B59C12B0068F2C6 /* MixpanelPresentationObject.m in Sources */,
 				05F5F9671965F5680070280C /* MPABTestDesignerClearResponseMessage.m in Sources */,
 				C38D5441C78F3F33FD640279 /* MPEnumDescription.m in Sources */,
 				C38D5AE963B48C6752645A38 /* MPTypeDescription.m in Sources */,

--- a/Mixpanel/Mixpanel.h
+++ b/Mixpanel/Mixpanel.h
@@ -948,4 +948,21 @@
  */
 - (BOOL)mixpanelWillFlush:(Mixpanel *)mixpanel;
 
+/*!
+ @method
+ 
+ @abstract
+ Tells the delegate that mixpanel checked for notifications and surveys on applicationDidBecomeActive
+ 
+ @discussion
+ This is an optional delegate method added to the Mixpanel library. The intention 
+ is to allow the host application know if Mixpanel is going to display a notification
+ and make UI adjustments if necessary.
+ 
+ @param mixpanel        Mixpanel API instance
+ @param notifications   Array of notifications
+ @param surveys         Array of surveys
+ */
+- (void)mixpanelOnActiveCheck:(Mixpanel *)mixpanel forNotifications:(NSArray*)notifications andSurveys:(NSArray*)surveys;
+
 @end

--- a/Mixpanel/Mixpanel.h
+++ b/Mixpanel/Mixpanel.h
@@ -962,6 +962,6 @@
  @param notifications   Array of notifications
  @param surveys         Array of surveys
  */
-- (void)mixpanelOnActiveCheck:(Mixpanel *)mixpanel forNotifications:(NSArray*)notifications andSurveys:(NSArray*)surveys;
+- (void)mixpanelOnActiveCheck:(Mixpanel *)mixpanel forNotifications:(NSArray *)notifications andSurveys:(NSArray *)surveys;
 
 @end

--- a/Mixpanel/Mixpanel.h
+++ b/Mixpanel/Mixpanel.h
@@ -952,12 +952,11 @@
  @method
  
  @abstract
- Tells the delegate that mixpanel checked for notifications and surveys on applicationDidBecomeActive
+ Tells the delegate that mixpanel checked for notifications and surveys on applicationDidBecomeActive.
  
  @discussion
- This is an optional delegate method added to the Mixpanel library. The intention 
- is to allow the host application know if Mixpanel is going to display a notification
- and make UI adjustments if necessary.
+ Gives the host application the opportunity to know if Mixpanel is going to display a notification or
+ survey.
  
  @param mixpanel        Mixpanel API instance
  @param notifications   Array of notifications

--- a/Mixpanel/Mixpanel.h
+++ b/Mixpanel/Mixpanel.h
@@ -957,6 +957,9 @@
  
  @discussion
  Return YES to have Mixpanel display a survey or notification immediately, NO to supress it.
+ objectArray contains MixpanelPresentationObject instances for all notifications and surveys 
+ available to be shown. Returning YES will display the first item in the array, preferring
+ notifications over surveys.
  
  @param mixpanel        Mixpanel API instance
  @param objectArray     Array of MixpanelPresentationObject instances.

--- a/Mixpanel/Mixpanel.h
+++ b/Mixpanel/Mixpanel.h
@@ -3,6 +3,7 @@
 #import <UIKit/UIKit.h>
 
 @class    MixpanelPeople;
+@class    MixpanelPresentationObject;
 @protocol MixpanelDelegate;
 
 /*!
@@ -952,16 +953,14 @@
  @method
  
  @abstract
- Tells the delegate that mixpanel checked for notifications and surveys on applicationDidBecomeActive.
+ Asks the delegate if notification or survey may be shown.
  
  @discussion
- Gives the host application the opportunity to know if Mixpanel is going to display a notification or
- survey.
+ Return YES to have Mixpanel display a survey or notification immediately, NO to supress it.
  
  @param mixpanel        Mixpanel API instance
- @param notifications   Array of notifications
- @param surveys         Array of surveys
+ @param objectArray     Array of MixpanelPresentationObject instances.
  */
-- (void)mixpanelOnActiveCheck:(Mixpanel *)mixpanel forNotifications:(NSArray *)notifications andSurveys:(NSArray *)surveys;
+- (BOOL)mixpanel:(Mixpanel *)mixpanel willShowNotificationOrSurveyFromArray:(NSArray *)objectArray;
 
 @end

--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -1091,6 +1091,12 @@ static void MixpanelReachabilityCallback(SCNetworkReachabilityRef target, SCNetw
         NSDate *start = [NSDate date];
 
         [self checkForDecideResponseWithCompletion:^(NSArray *surveys, NSArray *notifications, NSSet *variants, NSSet *eventBindings) {
+            
+            __strong id<MixpanelDelegate> strongDelegate = self.delegate;
+            if (strongDelegate != nil && [strongDelegate respondsToSelector:@selector(mixpanelOnActiveCheck:forNotifications:andSurveys:)]) {
+                [strongDelegate mixpanelOnActiveCheck:self forNotifications:notifications andSurveys:surveys];
+            }
+            
             if (self.showNotificationOnActive && notifications && [notifications count] > 0) {
                 [self showNotificationWithObject:notifications[0]];
             } else if (self.showSurveyOnActive && surveys && [surveys count] > 0) {

--- a/Mixpanel/MixpanelPresentationObject.h
+++ b/Mixpanel/MixpanelPresentationObject.h
@@ -1,0 +1,18 @@
+#import <Foundation/Foundation.h>
+
+typedef NS_ENUM(NSUInteger, MPPresentationObjectType) {
+    // beginning at 1 so that 0 can be utilized for unknown object type if need be someday
+    MPPresentationObjectTypeSurvey = 1,
+    MPPresentationObjectTypeNotification = 2
+};
+
+@interface MixpanelPresentationObject : NSObject
+
+@property (nonatomic, readonly) NSUInteger ID;
+@property (nonatomic, readonly) MPPresentationObjectType objectType;
+
+- (instancetype)initWithID:(NSUInteger)ID objectType:(MPPresentationObjectType)objectType;
+
+- (instancetype)init __unavailable;
+
+@end

--- a/Mixpanel/MixpanelPresentationObject.h
+++ b/Mixpanel/MixpanelPresentationObject.h
@@ -6,9 +6,42 @@ typedef NS_ENUM(NSUInteger, MPPresentationObjectType) {
     MPPresentationObjectTypeNotification = 2
 };
 
+/*!
+ @class
+ Mixpanel Presentation Object.
+ 
+ @abstract
+ Corresponds to either a notification or survey type.
+ 
+ @discussion
+ <b>You should not instantiate this object yourself.</b> An instance of it will
+ be provided within the objectArray parameter of the delegate method:
+ <pre>
+ - (BOOL)mixpanel:(Mixpanel *)mixpanel willShowNotificationOrSurveyFromArray:(NSArray *)objectArray;
+ </pre>
+ */
 @interface MixpanelPresentationObject : NSObject
 
+/*!
+ @property
+ 
+ @abstract
+ Corresponds to either a notification or survey ID.
+ 
+ @discussion
+ Query objectType to determine wether this is a survey or notification ID.
+ */
 @property (nonatomic, readonly) NSUInteger ID;
+
+/*!
+ @property
+ 
+ @abstract
+ Denotes wether this object corresponds to a survey or notification.
+ 
+ @discussion
+ Use this to determine what type of ID the ID property corresponds to (survey or notification).
+ */
 @property (nonatomic, readonly) MPPresentationObjectType objectType;
 
 - (instancetype)initWithID:(NSUInteger)ID objectType:(MPPresentationObjectType)objectType;

--- a/Mixpanel/MixpanelPresentationObject.m
+++ b/Mixpanel/MixpanelPresentationObject.m
@@ -1,0 +1,17 @@
+#if ! __has_feature(objc_arc)
+#error This file must be compiled with ARC. Either turn on ARC for the project or use -fobjc-arc flag on this file.
+#endif
+
+#import "MixpanelPresentationObject.h"
+
+@implementation MixpanelPresentationObject
+
+- (instancetype)initWithID:(NSUInteger)ID objectType:(MPPresentationObjectType)objectType {
+    if (self = [super init]) {
+        _ID = ID;
+        _objectType = objectType;
+    }
+    return self;
+}
+
+@end


### PR DESCRIPTION
We require this in our app as we have multiple ways to display notifications and we don't want the systems colliding (i.e. we fixed an instance where Mixpanel would display a notification and our app would present another view controller immediately after, causing the notification from Mixpanel to flash). We wanted to have Mixpanel show its notification at the very beginning, but needed a way to give the app a "heads-up" so that it could halt the changing of views until the notification was dismissed. This pull request is a solution for this. Efforts were made to adhere to your coding/documentation conventions.