### PR TITLE
Add capability to get new notifications in real-time

### DIFF
--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -1367,6 +1367,19 @@ static void MixpanelReachabilityCallback(SCNetworkReachabilityRef target, SCNetw
     }];
 }
 
+- (void)checkForNewNotificaitonsWithCompletion:(void (^)(BOOL available))completion
+{ 
+    [self checkForDecideResponseWithCompletion:^(NSArray *surveys, NSArray *notifications, NSSet *variants, NSSet *eventBindings) {
+        if (completion) {
+            BOOL available = NO;
+            if(notifications.count){
+                available = YES;
+            }
+            completion(available);
+        }
+    } useCache:NO];
+}
+
 - (void)checkForVariantsWithCompletion:(void (^)(NSSet *variants))completion
 {
     [self checkForDecideResponseWithCompletion:^(NSArray *surveys, NSArray *notifications, NSSet *variants, NSSet *eventBindings) {
@@ -1529,6 +1542,11 @@ static void MixpanelReachabilityCallback(SCNetworkReachabilityRef target, SCNetw
             [self showNotificationWithObject:notifications[0]];
         }
     }];
+}
+
+- (NSInteger)notificationsCount 
+{
+    return [self.notifications count];
 }
 
 - (void)showNotificationWithType:(NSString *)type


### PR DESCRIPTION
On behalf of a customer, submitting this PR to add support for grabbing real-time notifications. Currently the cached decide response disables users from grabbing new notifications in real-time, preventing against notifications which want to be deployed in the same session where the user becomes eligible.

Another potential solution here is to add useCache:NO into the method checkForNotificaitonsWithCompletion to force a new response each time, but have not looked into this in detail.