### PR TITLE
fixing Xcode 7 warnings related to NS_DESIGNATED_INITIALIZER

### DIFF
--- a/Mixpanel/MPABTestDesignerConnection.h
+++ b/Mixpanel/MPABTestDesignerConnection.h
@@ -13,6 +13,8 @@ extern NSString *const kSessionVariantKey;
 @property (nonatomic, readonly) BOOL connected;
 @property (nonatomic, assign) BOOL sessionEnded;
 
+- (instancetype)init NS_UNAVAILABLE;
+
 - (instancetype)initWithURL:(NSURL *)url;
 - (instancetype)initWithURL:(NSURL *)url keepTrying:(BOOL)keepTrying connectCallback:(void (^)())connectCallback disconnectCallback:(void (^)())disconnectCallback NS_DESIGNATED_INITIALIZER;
 

--- a/Mixpanel/MPABTestDesignerConnection.m
+++ b/Mixpanel/MPABTestDesignerConnection.m
@@ -45,6 +45,8 @@ NSString * const kSessionVariantKey = @"session_variant";
     void (^_disconnectCallback)();
 }
 
+- (instancetype)init { @throw nil; }
+
 - (instancetype)initWithURL:(NSURL *)url keepTrying:(BOOL)keepTrying connectCallback:(void (^)())connectCallback disconnectCallback:(void (^)())disconnectCallback
 {
     self = [super init];

--- a/Mixpanel/MPAbstractABTestDesignerMessage.h
+++ b/Mixpanel/MPAbstractABTestDesignerMessage.h
@@ -10,6 +10,8 @@
 
 + (instancetype)messageWithType:(NSString *)type payload:(NSDictionary *)payload;
 
+- (instancetype)init NS_UNAVAILABLE;
+
 - (instancetype)initWithType:(NSString *)type;
 - (instancetype)initWithType:(NSString *)type payload:(NSDictionary *)payload NS_DESIGNATED_INITIALIZER;
 

--- a/Mixpanel/MPAbstractABTestDesignerMessage.m
+++ b/Mixpanel/MPAbstractABTestDesignerMessage.m
@@ -21,6 +21,8 @@
     return [[self alloc] initWithType:type payload:payload];
 }
 
+- (instancetype)init { @throw nil; }
+
 - (instancetype)initWithType:(NSString *)type
 {
     return [self initWithType:type payload:@{}];

--- a/Mixpanel/MPApplicationStateSerializer.h
+++ b/Mixpanel/MPApplicationStateSerializer.h
@@ -8,6 +8,8 @@
 
 @interface MPApplicationStateSerializer : NSObject
 
+- (instancetype)init NS_UNAVAILABLE;
+
 - (instancetype)initWithApplication:(UIApplication *)application configuration:(MPObjectSerializerConfig *)configuration objectIdentityProvider:(MPObjectIdentityProvider *)objectIdentityProvider NS_DESIGNATED_INITIALIZER;
 
 - (UIImage *)screenshotImageForWindowAtIndex:(NSUInteger)index;

--- a/Mixpanel/MPApplicationStateSerializer.m
+++ b/Mixpanel/MPApplicationStateSerializer.m
@@ -16,6 +16,8 @@
     UIApplication *_application;
 }
 
+- (instancetype)init { @throw nil; }
+
 - (instancetype)initWithApplication:(UIApplication *)application configuration:(MPObjectSerializerConfig *)configuration objectIdentityProvider:(MPObjectIdentityProvider *)objectIdentityProvider
 {
     NSParameterAssert(application != nil);

--- a/Mixpanel/MPClassDescription.h
+++ b/Mixpanel/MPClassDescription.h
@@ -20,6 +20,8 @@
 
 @property (nonatomic, readonly) NSString *selectorName;
 
+- (instancetype)init NS_UNAVAILABLE;
+
 - (instancetype)initWithDictionary:(NSDictionary *)dictionary NS_DESIGNATED_INITIALIZER;
 
 @end

--- a/Mixpanel/MPClassDescription.m
+++ b/Mixpanel/MPClassDescription.m
@@ -6,6 +6,8 @@
 
 @implementation MPDelegateInfo
 
+- (instancetype)init { @throw nil; }
+
 - (instancetype)initWithDictionary:(NSDictionary *)dictionary
 {
     if (self = [super init]) {

--- a/Mixpanel/MPEventBinding.m
+++ b/Mixpanel/MPEventBinding.m
@@ -41,6 +41,8 @@
     [[Mixpanel sharedInstance] track:event properties:bindingProperties];
 }
 
+- (instancetype)init { @throw nil; }
+
 - (instancetype)initWithEventName:(NSString *)eventName onPath:(NSString *)path
 {
     if (self = [super init]) {

--- a/Mixpanel/MPNotificationViewController.m
+++ b/Mixpanel/MPNotificationViewController.m
@@ -23,6 +23,7 @@
 
 @interface ElasticEaseOutAnimation : CAKeyframeAnimation {}
 
+- (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithStartValue:(CGRect)start endValue:(CGRect)end andDuration:(double)duration NS_DESIGNATED_INITIALIZER;
 
 @end
@@ -699,6 +700,8 @@
 @end
 
 @implementation ElasticEaseOutAnimation
+
+- (instancetype)init { @throw nil; }
 
 - (instancetype)initWithStartValue:(CGRect)start endValue:(CGRect)end andDuration:(double)duration
 {

--- a/Mixpanel/MPObjectSelector.h
+++ b/Mixpanel/MPObjectSelector.h
@@ -13,6 +13,7 @@
 @property (nonatomic, strong, readonly) NSString *string;
 
 + (MPObjectSelector *)objectSelectorWithString:(NSString *)string;
+- (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithString:(NSString *)string NS_DESIGNATED_INITIALIZER;
 
 - (NSArray *)selectFromRoot:(id)root;

--- a/Mixpanel/MPObjectSelector.m
+++ b/Mixpanel/MPObjectSelector.m
@@ -48,6 +48,8 @@
     return [[MPObjectSelector alloc] initWithString:string];
 }
 
+- (instancetype)init { @throw nil; }
+
 - (instancetype)initWithString:(NSString *)string
 {
     if (self = [super init]) {

--- a/Mixpanel/MPObjectSerializer.h
+++ b/Mixpanel/MPObjectSerializer.h
@@ -10,6 +10,8 @@
 
 @interface MPObjectSerializer : NSObject
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /*!
  @param     An array of MPClassDescription instances.
  */

--- a/Mixpanel/MPObjectSerializer.m
+++ b/Mixpanel/MPObjectSerializer.m
@@ -23,6 +23,8 @@
     MPObjectIdentityProvider *_objectIdentityProvider;
 }
 
+- (instancetype)init { @throw nil; }
+
 - (instancetype)initWithConfiguration:(MPObjectSerializerConfig *)configuration objectIdentityProvider:(MPObjectIdentityProvider *)objectIdentityProvider
 {
     self = [super init];

--- a/Mixpanel/MPObjectSerializerConfig.h
+++ b/Mixpanel/MPObjectSerializerConfig.h
@@ -13,6 +13,8 @@
 @property (nonatomic, readonly) NSArray *classDescriptions;
 @property (nonatomic, readonly) NSArray *enumDescriptions;
 
+- (instancetype)init NS_UNAVAILABLE;
+
 - (instancetype)initWithDictionary:(NSDictionary *)dictionary NS_DESIGNATED_INITIALIZER;
 
 - (MPTypeDescription *)typeWithName:(NSString *)name;

--- a/Mixpanel/MPObjectSerializerConfig.m
+++ b/Mixpanel/MPObjectSerializerConfig.m
@@ -13,6 +13,8 @@
     NSDictionary *_enums;
 }
 
+- (instancetype)init { @throw nil; }
+
 - (instancetype)initWithDictionary:(NSDictionary *)dictionary
 {
     self = [super init];

--- a/Mixpanel/MPObjectSerializerContext.h
+++ b/Mixpanel/MPObjectSerializerContext.h
@@ -5,6 +5,8 @@
 
 @interface MPObjectSerializerContext : NSObject
 
+- (instancetype)init NS_UNAVAILABLE;
+
 - (instancetype)initWithRootObject:(id)object NS_DESIGNATED_INITIALIZER;
 
 - (BOOL)hasUnvisitedObjects;

--- a/Mixpanel/MPObjectSerializerContext.m
+++ b/Mixpanel/MPObjectSerializerContext.m
@@ -11,6 +11,8 @@
     NSMutableDictionary *_serializedObjects;
 }
 
+- (instancetype)init { @throw nil; }
+
 - (instancetype)initWithRootObject:(id)object
 {
     self = [super init];

--- a/Mixpanel/MPPropertyDescription.h
+++ b/Mixpanel/MPPropertyDescription.h
@@ -7,6 +7,8 @@
 
 @interface MPPropertySelectorParameterDescription : NSObject
 
+- (instancetype)init NS_UNAVAILABLE;
+
 - (instancetype)initWithDictionary:(NSDictionary *)dictionary NS_DESIGNATED_INITIALIZER;
 @property (nonatomic, readonly) NSString *name;
 @property (nonatomic, readonly) NSString *type;
@@ -14,6 +16,8 @@
 @end
 
 @interface MPPropertySelectorDescription : NSObject
+
+- (instancetype)init NS_UNAVAILABLE;
 
 - (instancetype)initWithDictionary:(NSDictionary *)dictionary NS_DESIGNATED_INITIALIZER;
 @property (nonatomic, readonly) NSString *selectorName;
@@ -23,6 +27,8 @@
 @end
 
 @interface MPPropertyDescription : NSObject
+
+- (instancetype)init NS_UNAVAILABLE;
 
 - (instancetype)initWithDictionary:(NSDictionary *)dictionary NS_DESIGNATED_INITIALIZER;
 

--- a/Mixpanel/MPPropertyDescription.m
+++ b/Mixpanel/MPPropertyDescription.m
@@ -5,6 +5,8 @@
 
 @implementation MPPropertySelectorParameterDescription
 
+- (instancetype)init { @throw nil; }
+
 - (instancetype)initWithDictionary:(NSDictionary *)dictionary
 {
     NSParameterAssert(dictionary[@"name"] != nil);
@@ -22,6 +24,8 @@
 @end
 
 @implementation MPPropertySelectorDescription
+
+- (instancetype)init { @throw nil; }
 
 - (instancetype)initWithDictionary:(NSDictionary *)dictionary
 {
@@ -68,6 +72,8 @@
     // Default to pass-through.
     return [NSValueTransformer valueTransformerForName:@"MPPassThroughValueTransformer"];
 }
+
+- (instancetype)init { @throw nil; }
 
 - (instancetype)initWithDictionary:(NSDictionary *)dictionary
 {

--- a/Mixpanel/MPTweak.h
+++ b/Mixpanel/MPTweak.h
@@ -24,6 +24,8 @@ typedef id MPTweakValue;
  */
 @interface MPTweak : NSObject
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /**
   @abstract Creates a new tweak model.
   @discussion This is the designated initializer.

--- a/Mixpanel/MPTweak.m
+++ b/Mixpanel/MPTweak.m
@@ -13,6 +13,8 @@
   NSHashTable *_observers;
 }
 
+- (instancetype)init { @throw nil; }
+
 - (instancetype)initWithName:(NSString *)name andEncoding:(NSString *)encoding
 {
   if ((self = [super init])) {

--- a/Mixpanel/MPWebSocket.h
+++ b/Mixpanel/MPWebSocket.h
@@ -48,6 +48,8 @@ extern NSString *const MPWebSocketErrorDomain;
 // It will be nil until after the handshake completes.
 @property (nonatomic, readonly, copy) NSString *protocol;
 
+- (instancetype)init NS_UNAVAILABLE;
+
 // Protocols should be an array of strings that turn into Sec-WebSocket-Protocol.
 - (instancetype)initWithURLRequest:(NSURLRequest *)request protocols:(NSArray *)protocols NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithURLRequest:(NSURLRequest *)request;

--- a/Mixpanel/MPWebSocket.m
+++ b/Mixpanel/MPWebSocket.m
@@ -294,6 +294,8 @@ static __strong NSData *CRLFCRLF;
     CRLFCRLF = [[NSData alloc] initWithBytes:"\r\n\r\n" length:4];
 }
 
+- (instancetype)init { @throw nil; }
+
 - (instancetype)initWithURLRequest:(NSURLRequest *)request protocols:(NSArray *)protocols;
 {
     self = [super init];

--- a/Mixpanel/_MPTweakBindObserver.h
+++ b/Mixpanel/_MPTweakBindObserver.h
@@ -23,6 +23,8 @@ typedef void (^_MPTweakBindObserverBlock)(id object);
  */
 @interface _MPTweakBindObserver : NSObject
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /**
   @abstract Designated initializer.
   @param tweak The tweak to observe.

--- a/Mixpanel/_MPTweakBindObserver.m
+++ b/Mixpanel/_MPTweakBindObserver.m
@@ -21,6 +21,8 @@
   __weak id _object;
 }
 
+- (instancetype)init { @throw nil; }
+
 - (instancetype)initWithTweak:(MPTweak *)tweak block:(_MPTweakBindObserverBlock)block
 {
   if ((self = [super init])) {


### PR DESCRIPTION
This patch is following my own recommandation on the matter: https://stackoverflow.com/questions/29639040/warning-method-override-for-designated-initializer/31830471#31830471

If approved, it supersedes https://github.com/mixpanel/mixpanel-iphone/pull/307