### PR TITLE
Reset `shownNotifications` on Mixpanel#reset call

### DIFF
--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -545,6 +545,7 @@ static __unused NSString *MPURLEncode(NSString *s)
         self.peopleQueue = [NSMutableArray array];
         self.timedEvents = [NSMutableDictionary dictionary];
         self.shownSurveyCollections = [NSMutableSet set];
+        self.shownNotifications = [NSMutableSet set];
         self.decideResponseCached = NO;
         [self archive];
     });


### PR DESCRIPTION
In continuation of https://github.com/mixpanel/mixpanel-iphone/issues/232#issuecomment-135206887