### PR TITLE
Set indentation in Xcode project

### DIFF
--- a/HelloMixpanel/HelloMixpanel.xcodeproj/project.pbxproj
+++ b/HelloMixpanel/HelloMixpanel.xcodeproj/project.pbxproj
@@ -636,7 +636,9 @@
 				2808F9981610EFE3005772B7 /* Supporting Files */,
 				9003ECED95D33B569C44DB53 /* Pods */,
 			);
+			indentWidth = 4;
 			sourceTree = "<group>";
+			tabWidth = 4;
 		};
 		2808F98E1610EFE3005772B7 /* Products */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
I have 2 space indentation set up in global Xcode preferences.

<img width="452" alt="2015-08-30_2208" src="https://cloud.githubusercontent.com/assets/217368/9572362/a6c32ef0-4f63-11e5-93c7-1c043a85ec8f.png">

So when I was editing a file in this project Xcode was indenting everything with 2 spaces. So I had to fix indentation manually to match your coding style.

Fortunately Xcode has an option to set up indentation in project file :)

<img width="257" alt="2015-08-30_2206" src="https://cloud.githubusercontent.com/assets/217368/9572346/633b6954-4f63-11e5-8c1a-47733e906e78.png">
