### PR TITLE
Don't present Notifications on top of UIAlertController

### DIFF
--- a/HelloMixpanel/HelloMixpanelTests/HelloMixpanelTests.m
+++ b/HelloMixpanel/HelloMixpanelTests/HelloMixpanelTests.m
@@ -1173,6 +1173,24 @@
 
     topVC = [self topViewController];
     XCTAssertFalse([topVC isKindOfClass:[MPNotificationViewController class]], @"Notification was presented");
+
+    // Dismiss the alert and try to present notification again
+    waitForBlock = YES;
+    [topVC dismissViewControllerAnimated:YES completion:^{
+        waitForBlock = NO;
+    }];
+
+    while(waitForBlock) {
+        [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
+    }
+
+    [self.mixpanel showNotificationWithObject:notif];
+
+    //wait for notifs to be shown from main queue
+    [self waitForAsyncQueue];
+
+    topVC = [self topViewController];
+    XCTAssertTrue([topVC isKindOfClass:[MPNotificationViewController class]], @"Notification wasn't presented");
 }
 
 - (void)testNoShowSurveyOnPresentingVC

--- a/HelloMixpanel/HelloMixpanelTests/HelloMixpanelTests.m
+++ b/HelloMixpanel/HelloMixpanelTests/HelloMixpanelTests.m
@@ -1141,6 +1141,40 @@
     }
 }
 
+- (void)testNoShowNotificationOnAlertController
+{
+    UIViewController *topVC = [self topViewController];
+
+    UIAlertController *alertController = [UIAlertController alertControllerWithTitle:@"Alert" message:nil preferredStyle:UIAlertControllerStyleAlert];
+    [alertController addAction:[UIAlertAction actionWithTitle:@"Ok" style:UIAlertActionStyleDefault handler:nil]];
+
+    __block BOOL waitForBlock = YES;
+    [topVC presentViewController:alertController animated:NO completion:^{
+        waitForBlock = NO;
+    }];
+
+    while(waitForBlock) {
+        [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
+    }
+
+    NSDictionary *o = @{@"id": @3,
+                        @"message_id": @1,
+                        @"title": @"title",
+                        @"type": @"takeover",
+                        @"body": @"body",
+                        @"cta": @"cta",
+                        @"cta_url": @"maps://",
+                        @"image_url": @"http://cdn.mxpnl.com/site_media/images/engage/inapp_messages/mini/icon_coin.png"};
+    MPNotification *notif = [MPNotification notificationWithJSONObject:o];
+    [self.mixpanel showNotificationWithObject:notif];
+
+    //wait for notifs to be shown from main queue
+    [self waitForAsyncQueue];
+
+    topVC = [self topViewController];
+    XCTAssertFalse([topVC isKindOfClass:[MPNotificationViewController class]], @"Notification was presented");
+}
+
 - (void)testNoShowSurveyOnPresentingVC
 {
     NSDictionary *o = @{@"id": @3,

--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -1197,6 +1197,17 @@ static void MixpanelReachabilityCallback(SCNetworkReachabilityRef target, SCNetw
     return controller;
 }
 
++ (BOOL)canPresentFromViewController:(UIViewController *)viewController
+{
+    // This fixes the NSInternalInconsistencyException caused when we try present a
+    // survey on a viewcontroller that is itself being presented.
+    if ([viewController isBeingPresented] || [viewController isBeingDismissed]) {
+        return NO;
+    }
+
+    return YES;
+}
+
 - (void)checkForDecideResponseWithCompletion:(void (^)(NSArray *surveys, NSArray *notifications, NSSet *variants, NSSet *eventBindings))completion
 {
     [self checkForDecideResponseWithCompletion:completion useCache:YES];
@@ -1390,10 +1401,7 @@ static void MixpanelReachabilityCallback(SCNetworkReachabilityRef target, SCNetw
 {
     UIViewController *presentingViewController = [Mixpanel topPresentedViewController];
 
-    // This fixes the NSInternalInconsistencyException caused when we try present a
-    // survey on a viewcontroller that is itself being presented.
-    if (![presentingViewController isBeingPresented] && ![presentingViewController isBeingDismissed]) {
-
+    if ([[self class] canPresentFromViewController:presentingViewController]) {
         UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"MPSurvey" bundle:[NSBundle bundleForClass:Mixpanel.class]];
         MPSurveyNavigationController *controller = [storyboard instantiateViewControllerWithIdentifier:@"MPSurveyNavigationController"];
         controller.survey = survey;
@@ -1604,7 +1612,7 @@ static void MixpanelReachabilityCallback(SCNetworkReachabilityRef target, SCNetw
 {
     UIViewController *presentingViewController = [Mixpanel topPresentedViewController];
 
-    if (![presentingViewController isBeingPresented] && ![presentingViewController isBeingDismissed]) {
+    if ([[self class] canPresentFromViewController:presentingViewController]) {
         UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"MPNotification" bundle:[NSBundle bundleForClass:Mixpanel.class]];
         MPTakeoverNotificationViewController *controller = [storyboard instantiateViewControllerWithIdentifier:@"MPNotificationViewController"];
 

--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -1205,6 +1205,11 @@ static void MixpanelReachabilityCallback(SCNetworkReachabilityRef target, SCNetw
         return NO;
     }
 
+    Class UIAlertControllerClass = NSClassFromString(@"UIAlertController");
+    if (UIAlertControllerClass && [viewController isKindOfClass:UIAlertControllerClass]) {
+        return NO;
+    }
+
     return YES;
 }
 

--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -1609,6 +1609,10 @@ static void MixpanelReachabilityCallback(SCNetworkReachabilityRef target, SCNetw
             if (shown && ![notification.title isEqualToString:@"$ignore"]) {
                 [self markNotificationShown:notification];
             }
+
+            if (!shown) {
+                self.currentlyShowingNotification = nil;
+            }
         }
     });
 }


### PR DESCRIPTION
This pull request fixes an issue explained in #268

Additionally it fixes an issue when Notifications and Surveys were prevented from being presented if a notifications has been failed to be presented before.