### PR TITLE
Add property to customize in-app mini notifications background

### DIFF
--- a/Mixpanel/MPNotificationViewController.h
+++ b/Mixpanel/MPNotificationViewController.h
@@ -23,6 +23,8 @@
 
 @interface MPMiniNotificationViewController : MPNotificationViewController
 
+@property (nonatomic, strong) UIColor *backgroundColor;
+
 - (void)showWithAnimation;
 
 @end

--- a/Mixpanel/MPNotificationViewController.m
+++ b/Mixpanel/MPNotificationViewController.m
@@ -271,12 +271,15 @@
     self.bodyLabel.lineBreakMode = NSLineBreakByWordWrapping;
     self.bodyLabel.numberOfLines = 0;
 
-    UIColor *backgroundColor = [UIColor mp_applicationPrimaryColor];
-    if (!backgroundColor) {
-        backgroundColor = [UIColor mp_darkEffectColor];
+    if (!self.backgroundColor) {
+        self.backgroundColor = [UIColor mp_applicationPrimaryColor];
+        if (!self.backgroundColor) {
+            self.backgroundColor = [UIColor mp_darkEffectColor];
+        }
     }
-    backgroundColor = [backgroundColor colorWithAlphaComponent:0.95f];
-    self.view.backgroundColor = backgroundColor;
+
+    UIColor *backgroundColorWithAlphaComponent = [self.backgroundColor colorWithAlphaComponent:0.95f];
+    self.view.backgroundColor = backgroundColorWithAlphaComponent;
 
     if (self.notification != nil) {
         if (self.notification.image != nil) {

--- a/Mixpanel/Mixpanel.h
+++ b/Mixpanel/Mixpanel.h
@@ -201,6 +201,19 @@
 
 /*!
  @property
+ 
+ @abstract
+ If set, determines the background color of mini notifications.
+
+ @discussion
+ If this isn't set, we default to either the color of the UINavigationBar of the top 
+ UINavigationController that is showing when the notification is presented, the 
+ UINavigationBar default color for the app or the UITabBar default color.
+ */
+@property (atomic) UIColor* miniNotificationBackgroundColor;
+
+/*!
+ @property
 
  @abstract
  The a MixpanelDelegate object that can be used to assert fine-grain control

--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -155,6 +155,7 @@ static Mixpanel *sharedInstance = nil;
         self.checkForVariantsOnActive = YES;
         self.checkForSurveysOnActive = YES;
         self.miniNotificationPresentationTime = 6.0;
+        self.miniNotificationBackgroundColor = nil;
 
         self.distinctId = [self defaultDistinctId];
         self.superProperties = [NSMutableDictionary dictionary];
@@ -1625,6 +1626,7 @@ static void MixpanelReachabilityCallback(SCNetworkReachabilityRef target, SCNetw
     MPMiniNotificationViewController *controller = [[MPMiniNotificationViewController alloc] init];
     controller.notification = notification;
     controller.delegate = self;
+    controller.backgroundColor = self.miniNotificationBackgroundColor;
     self.notificationViewController = controller;
 
     [controller showWithAnimation];


### PR DESCRIPTION
* Added a new property called miniNotiicationBackgroundColor to primary interface
* Setting this property will set the background color of the notification view
* If this property is not set, we fall back to previous behavior