### PR TITLE
Fix in-app messages on lanscape mode

### DIFF
--- a/Mixpanel/MPNotificationViewController.m
+++ b/Mixpanel/MPNotificationViewController.m
@@ -120,8 +120,8 @@
     [self.okayButton addTarget:self action:@selector(pressedOkay) forControlEvents:UIControlEventTouchUpInside];
     [self.closeButton addTarget:self action:@selector(pressedClose) forControlEvents:UIControlEventTouchUpInside];
 
-    UIPanGestureRecognizer *gesture = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(didPan:)];
-    [self.imageDragView addGestureRecognizer:gesture];
+//    UIPanGestureRecognizer *gesture = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(didPan:)];
+//    [self.imageDragView addGestureRecognizer:gesture];
 }
 
 - (void)hideWithAnimation:(BOOL)animated completion:(void (^)(void))completion
@@ -153,7 +153,7 @@
 - (NSUInteger)supportedInterfaceOrientations
 #endif
 {
-    return UIInterfaceOrientationMaskPortrait;
+    return UIInterfaceOrientationMaskAll;
 }
 
 - (void)beginAppearanceTransition:(BOOL)isAppearing animated:(BOOL)animated
@@ -597,7 +597,7 @@
 
 - (void)drawRect:(CGRect)rect
 {
-    CGPoint center = CGPointMake(160.0f, 200.0f);
+    CGPoint center = CGPointMake(self.center.x, 200.0f); //CGPointMake(160.0f, 200.0f);
     CGSize circleSize = CGSizeMake(center.y * 2.0f, center.y * 2.0f);
     CGRect circleFrame = CGRectMake(center.x - center.y, 0.0f, circleSize.width, circleSize.height);
 

--- a/Mixpanel/MPNotificationViewController.m
+++ b/Mixpanel/MPNotificationViewController.m
@@ -120,8 +120,8 @@
     [self.okayButton addTarget:self action:@selector(pressedOkay) forControlEvents:UIControlEventTouchUpInside];
     [self.closeButton addTarget:self action:@selector(pressedClose) forControlEvents:UIControlEventTouchUpInside];
 
-//    UIPanGestureRecognizer *gesture = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(didPan:)];
-//    [self.imageDragView addGestureRecognizer:gesture];
+    UIPanGestureRecognizer *gesture = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(didPan:)];
+    [self.imageDragView addGestureRecognizer:gesture];
 }
 
 - (void)hideWithAnimation:(BOOL)animated completion:(void (^)(void))completion
@@ -597,7 +597,7 @@
 
 - (void)drawRect:(CGRect)rect
 {
-    CGPoint center = CGPointMake(self.center.x, 200.0f); //CGPointMake(160.0f, 200.0f);
+    CGPoint center = CGPointMake(self.center.x, 200.0f);
     CGSize circleSize = CGSizeMake(center.y * 2.0f, center.y * 2.0f);
     CGRect circleFrame = CGRectMake(center.x - center.y, 0.0f, circleSize.width, circleSize.height);
 


### PR DESCRIPTION
The fix prevents crashes when getting In-app messages in apps that allow only landscape mode orientation. 