### PR TITLE
Require iOS 8 in the podspec

### DIFF
--- a/Mixpanel.podspec
+++ b/Mixpanel.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'https://mixpanel.com'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Mixpanel, Inc' => 'support@mixpanel.com' }
-  s.platform     = :ios, '6.0'
+  s.platform     = :ios, '8.0'
   s.source       = { :git => 'https://github.com/mixpanel/mixpanel-iphone.git', :tag => "v#{s.version}" }
   s.requires_arc = true
   s.default_subspec = 'Mixpanel'


### PR DESCRIPTION
Based on the release notes: https://github.com/mixpanel/mixpanel-iphone/releases/tag/v2.9.0