### PR TITLE
Open url after MPTakeoverNotificationViewController is dismissed

### DIFF
--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -1758,16 +1758,17 @@ static void MixpanelReachabilityCallback(SCNetworkReachabilityRef target, SCNetw
     };
 
     if (status && controller.notification.callToActionURL) {
-        MixpanelDebug(@"%@ opening URL %@", self, controller.notification.callToActionURL);
-        BOOL success = [[UIApplication sharedApplication] openURL:controller.notification.callToActionURL];
+        [controller hideWithAnimation:YES completion:^{
+            NSURL *URL = controller.notification.callToActionURL;
+            MixpanelDebug(@"%@ opening URL %@", self, URL);
 
-        [controller hideWithAnimation:!success completion:completionBlock];
+            if (![[UIApplication sharedApplication] openURL:URL]) {
+                MixpanelError(@"Mixpanel failed to open given URL: %@", URL);
+            }
 
-        if (!success) {
-            MixpanelError(@"Mixpanel failed to open given URL: %@", controller.notification.callToActionURL);
-        }
-
-        [self trackNotification:controller.notification event:@"$campaign_open"];
+            [self trackNotification:controller.notification event:@"$campaign_open"];
+            completionBlock();
+        }];
     } else {
         [controller hideWithAnimation:YES completion:completionBlock];
     }


### PR DESCRIPTION
We are using takeover (full screen) notifications. When user interacts with them Mixpanel sdk launches an url which is handled by our app. 

In our case those urls are handled by presenting some view controller on top of current top presented controller.

The problem we hit pretty often is that the our view controller is not presented. And in console I see something like:

> Warning: Attempt to present <UINavigationController: 0x134a5b600> on <MPTakeoverNotificationViewController: 0x136a37650> whose view is not in the window hierarchy!

I suppose this happens because in current implementation `[[UIApplication sharedApplication] openURL:url]` is called first and after that `MPTakeoverNotificationViewController` get dismissed. So at the time our url handled gets called `MPTakeoverNotificationViewController` is not completely dismissed and is still top presented view controller.

With this fix the problem seems to be solved :)

