### PR TITLE
Option to suppress IP Address collection

### DIFF
--- a/Mixpanel/Mixpanel.h
+++ b/Mixpanel/Mixpanel.h
@@ -189,6 +189,20 @@
 
 /*!
  @property
+ 
+ @abstract
+ Controls whether to automatically send the device's IP Address to
+ Mixpanel. Transmission allows Mixpanel to geo-locate a user down to
+ city-level specification. For privacy reasons, you may need to forego
+ having such collection.
+ 
+ @discussion
+ Defaults to YES.
+ */
+@property (atomic) BOOL transmitIPAddress;
+
+/*!
+ @property
 
  @abstract
  Determines the time, in seconds, that a mini notification will remain on

--- a/Mixpanel/Mixpanel.h
+++ b/Mixpanel/Mixpanel.h
@@ -193,14 +193,14 @@
  @abstract
  Controls whether to automatically send the client IP Address as part of 
  event tracking. With an IP address, geo-location is possible down to neighborhoods
- with a city, although the Mixpanel Dashboard will just show you city level location
+ within a city, although the Mixpanel Dashboard will just show you city level location
  specificity. For privacy reasons, you may be in a situation where you need to forego
  effectively having access to such granular location information via the IP Address.
  
  @discussion
  Defaults to YES.
  */
-@property (atomic) BOOL transmitIPAddress;
+@property (atomic) BOOL useIPAddressForGeoLocation;
 
 /*!
  @property

--- a/Mixpanel/Mixpanel.h
+++ b/Mixpanel/Mixpanel.h
@@ -191,10 +191,11 @@
  @property
  
  @abstract
- Controls whether to automatically send the device's IP Address to
- Mixpanel. Transmission allows Mixpanel to geo-locate a user down to
- city-level specification. For privacy reasons, you may need to forego
- having such collection.
+ Controls whether to automatically send the client IP Address as part of 
+ event tracking. With an IP address, geo-location is possible down to neighborhoods
+ with a city, although the Mixpanel Dashboard will just show you city level location
+ specificity. For privacy reasons, you may be in a situation where you need to forego
+ effectively having access to such granular location information via the IP Address.
  
  @discussion
  Defaults to YES.

--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -145,7 +145,7 @@ static Mixpanel *sharedInstance = nil;
         _flushInterval = flushInterval;
         self.flushOnBackground = YES;
         self.showNetworkActivityIndicator = YES;
-        self.transmitIPAddress = YES;
+        self.useIPAddressForGeoLocation = YES;
 
         self.serverURL = @"https://api.mixpanel.com";
         self.decideURL = @"https://decide.mixpanel.com";
@@ -643,7 +643,7 @@ static __unused NSString *MPURLEncode(NSString *s)
         NSArray *batch = [queue subarrayWithRange:NSMakeRange(0, batchSize)];
 
         NSString *requestData = [self encodeAPIData:batch];
-        NSString *postBody = [NSString stringWithFormat:@"ip=%d&data=%@", self.transmitIPAddress, requestData];
+        NSString *postBody = [NSString stringWithFormat:@"ip=%d&data=%@", self.useIPAddressForGeoLocation, requestData];
         MixpanelDebug(@"%@ flushing %lu of %lu to %@: %@", self, (unsigned long)[batch count], (unsigned long)[queue count], endpoint, queue);
         NSURLRequest *request = [self apiRequestWithEndpoint:endpoint andBody:postBody];
         NSError *error = nil;

--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -145,6 +145,7 @@ static Mixpanel *sharedInstance = nil;
         _flushInterval = flushInterval;
         self.flushOnBackground = YES;
         self.showNetworkActivityIndicator = YES;
+        self.transmitIPAddress = YES;
 
         self.serverURL = @"https://api.mixpanel.com";
         self.decideURL = @"https://decide.mixpanel.com";
@@ -642,7 +643,7 @@ static __unused NSString *MPURLEncode(NSString *s)
         NSArray *batch = [queue subarrayWithRange:NSMakeRange(0, batchSize)];
 
         NSString *requestData = [self encodeAPIData:batch];
-        NSString *postBody = [NSString stringWithFormat:@"ip=1&data=%@", requestData];
+        NSString *postBody = [NSString stringWithFormat:@"ip=%d&data=%@", self.transmitIPAddress, requestData];
         MixpanelDebug(@"%@ flushing %lu of %lu to %@: %@", self, (unsigned long)[batch count], (unsigned long)[queue count], endpoint, queue);
         NSURLRequest *request = [self apiRequestWithEndpoint:endpoint andBody:postBody];
         NSError *error = nil;


### PR DESCRIPTION
This feature lets client integrations decide on whether IP addresses should be sent along with other event tracking data. Normally, we want as much data as we can get, including the wonderful geo-location benefits possible with sending an IP address with events.

However, in some scenarios, our client app's privacy policies don't permit having the level of location specificity that is possible with an IP address.

As such, it is useful to be able to control whether we continue to transmit IP addresses (the default) or suppress doing so.

###### Usage Example

```
    // Initialize the library with our mixpanel token:
    [Mixpanel sharedInstanceWithToken:mixpanelToken];
    
    // Retrieve singleton instance of underlying analytics provider:
    self.analyticsProvider = [Mixpanel sharedInstance];
    self.analyticsProvider.transmitIPAddress = NO;
```