### PR TITLE
Documentation fixes in Mixpanel.h to fix iOS sample code

### DIFF
--- a/Mixpanel/Mixpanel.h
+++ b/Mixpanel/Mixpanel.h
@@ -25,7 +25,7 @@
  [mixpanel track:@"Button Clicked"];
 
  // Set properties on a user in Mixpanel People
- [mixpanel.people identify:@"CURRENT USER DISTINCT ID"];
+ [mixpanel identify:@"CURRENT USER DISTINCT ID"];
  [mixpanel.people set:@"Plan" to:@"Premium"];
  </pre>
 
@@ -734,7 +734,7 @@
  People methods will look like this:
 
  <pre>
- [mixpanel.people increment:@"App Opens" by:1];
+ [mixpanel.people increment:@"App Opens" by:[NSNumber numberWithInt:1]];
  </pre>
 
  Please note that the core <code>Mixpanel</code> and
@@ -789,9 +789,6 @@
  // applies to both Mixpanel Engagement track: AND Mixpanel People set: and
  // increment: calls
  [mixpanel identify:distinctId];
-
- // applies ONLY to Mixpanel People set: and increment: calls
- [mixpanel.people identify:distinctId];
  </pre>
 
  @param properties       properties dictionary


### PR DESCRIPTION
1. Pass NSNumber* instead of int where required for this method:
- (void)increment:(NSString *)property by:(NSNumber *)amount;

2. Replace this sample code line (which doesn't compile):
[mixpanel.people identify:@"CURRENT USER DISTINCT ID"];

...with this line:
[mixpanel identify:@"CURRENT USER DISTINCT ID"];

3. Remove this sample code line that doesn't compile:
[mixpanel.people identify:distinctId];