### PR TITLE
Flush events after setting flush interval

### DIFF
--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -566,6 +566,7 @@ static __unused NSString *MPURLEncode(NSString *s)
     @synchronized(self) {
         _flushInterval = interval;
     }
+    [self flush];
     [self startFlushTimer];
 }
 


### PR DESCRIPTION
If the flush interval is dynamically changing, we could end up in a situation where no events are sent during the user session.