### PR TITLE
Fixed crash when calling `checkForDecideResponseWithCompletion:useCache:` 

### DIFF
--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -836,7 +836,7 @@ static __unused NSString *MPURLEncode(NSString *s)
         self.shownSurveyCollections = properties[@"shownSurveyCollections"] ? properties[@"shownSurveyCollections"] : [NSMutableSet set];
         self.shownNotifications = properties[@"shownNotifications"] ? properties[@"shownNotifications"] : [NSMutableSet set];
         self.variants = properties[@"variants"] ? properties[@"variants"] : [NSSet set];
-        self.eventBindings = properties[@"event_bindings"] ? properties[@"event_bindings"] : [NSArray array];
+        self.eventBindings = properties[@"event_bindings"] ? properties[@"event_bindings"] : [NSSet set];
         self.timedEvents = properties[@"timedEvents"] ? properties[@"timedEvents"] : [NSMutableDictionary dictionary];
     }
 }
@@ -852,7 +852,7 @@ static __unused NSString *MPURLEncode(NSString *s)
 - (void)unarchiveEventBindings
 {
     self.eventBindings = (NSSet *)[self unarchiveFromFile:[self eventBindingsFilePath]];
-    if (!self.eventBindings) {
+    if (!self.eventBindings || ![self.eventBindings isKindOfClass:[NSSet class]]) {
         self.eventBindings = [NSSet set];
     }
 }


### PR DESCRIPTION
We get around 20 crashes a day with the following call stack. We debugged the issue and found an incorrectly initialised property. This fix prevents those crashes.

```
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '*** -[NSSet initWithSet:copyItems:]: set argument is not an NSSet'
*** First throw call stack:
(
	0   CoreFoundation                      0x04a4ca84 __exceptionPreprocess + 180
	1   libobjc.A.dylib                     0x04443e02 objc_exception_throw + 50
	2   CoreFoundation                      0x0497cf4f -[NSSet initWithSet:copyItems:] + 1231
	3   CoreFoundation                      0x0498e504 +[NSSet setWithSet:] + 68
	4   Mixpanel                            0x00cbe9ab __58-[Mixpanel checkForDecideResponseWithCompletion:useCache:]_block_invoke + 6347
	5   libdispatch.dylib                   0x05672377 _dispatch_call_block_and_release + 15
	6   libdispatch.dylib                   0x056959cd _dispatch_client_callout + 14
	7   libdispatch.dylib                   0x05679650 _dispatch_queue_drain + 2227
	8   libdispatch.dylib                   0x05678b04 _dispatch_queue_invoke + 570
	9   libdispatch.dylib                   0x0567b7bb _dispatch_root_queue_drain + 550
	10  libdispatch.dylib                   0x0567b58e _dispatch_worker_thread3 + 115
	11  libsystem_pthread.dylib             0x059b5270 _pthread_wqthread + 1050
	12  libsystem_pthread.dylib             0x059b2f82 start_wqthread + 34
)
libc++abi.dylib: terminating with uncaught exception of type NSException
```
 