### PR TITLE
Protect against nil dictionary access

### DIFF
--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -921,8 +921,10 @@ static __unused NSString *MPURLEncode(NSString *s)
 {
     dispatch_async(self.serialQueue, ^(){
         NSMutableDictionary *properties = [self.automaticProperties mutableCopy];
-        properties[@"$radio"] = [self currentRadio];
-        self.automaticProperties = [properties copy];
+        if (properties) {
+            properties[@"$radio"] = [self currentRadio];
+            self.automaticProperties = [properties copy];
+        }
     });
 }
 
@@ -1087,9 +1089,11 @@ static void MixpanelReachabilityCallback(SCNetworkReachabilityRef target, SCNetw
     // set to run on the serial queue. see SCNetworkReachabilitySetDispatchQueue in init
     BOOL wifi = (flags & kSCNetworkReachabilityFlagsReachable) && !(flags & kSCNetworkReachabilityFlagsIsWWAN);
     NSMutableDictionary *properties = [self.automaticProperties mutableCopy];
-    properties[@"$wifi"] = wifi ? @YES : @NO;
-    self.automaticProperties = [properties copy];
-    MixpanelDebug(@"%@ reachability changed, wifi=%d", self, wifi);
+    if (properties) {
+        properties[@"$wifi"] = wifi ? @YES : @NO;
+        self.automaticProperties = [properties copy];
+        MixpanelDebug(@"%@ reachability changed, wifi=%d", self, wifi);
+    }
 }
 
 - (void)applicationDidBecomeActive:(NSNotification *)notification


### PR DESCRIPTION
Our production app has been seeing crashes in the wild in these two Mixpanel functions. Both crash logs indicate invalid subscript access on the dictionary which led us to believe the mutableCopy failed to return a valid object for some reason.
<img width="510" alt="screen shot 2015-12-08 at 4 32 06 pm" src="https://cloud.githubusercontent.com/assets/906694/11672902/4266bbfc-9dc9-11e5-9369-8f0d8326e894.png">
<img width="557" alt="screen shot 2015-12-08 at 4 31 57 pm" src="https://cloud.githubusercontent.com/assets/906694/11672903/4276a094-9dc9-11e5-9cbf-30673ae041fa.png">

