### PR TITLE
Rename websocket categories so we won't collide with SRWebSocket.

### DIFF
--- a/Mixpanel/MPWebSocket.h
+++ b/Mixpanel/MPWebSocket.h
@@ -92,17 +92,17 @@ extern NSString *const MPWebSocketErrorDomain;
 
 @end
 
-#pragma mark - NSURLRequest (CertificateAdditions)
+#pragma mark - NSURLRequest (MPCertificateAdditions)
 
-@interface NSURLRequest (CertificateAdditions)
+@interface NSURLRequest (MPCertificateAdditions)
 
 @property (nonatomic, retain, readonly) NSArray *mp_SSLPinnedCertificates;
 
 @end
 
-#pragma mark - NSMutableURLRequest (CertificateAdditions)
+#pragma mark - NSMutableURLRequest (MPCertificateAdditions)
 
-@interface NSMutableURLRequest (CertificateAdditions)
+@interface NSMutableURLRequest (MPCertificateAdditions)
 
 @property (nonatomic, retain) NSArray *mp_SSLPinnedCertificates;
 

--- a/Mixpanel/MPWebSocket.m
+++ b/Mixpanel/MPWebSocket.m
@@ -1599,7 +1599,7 @@ static const size_t MPFrameHeaderOverhead = 32;
 @end
 
 
-@implementation  NSURLRequest (CertificateAdditions)
+@implementation  NSURLRequest (MPCertificateAdditions)
 
 - (NSArray *)mp_SSLPinnedCertificates;
 {
@@ -1608,7 +1608,7 @@ static const size_t MPFrameHeaderOverhead = 32;
 
 @end
 
-@implementation  NSMutableURLRequest (CertificateAdditions)
+@implementation  NSMutableURLRequest (MPCertificateAdditions)
 
 - (NSArray *)mp_SSLPinnedCertificates;
 {


### PR DESCRIPTION
Resolves #378