### PR TITLE
Add class method to get libversion

### DIFF
--- a/Mixpanel/Mixpanel.h
+++ b/Mixpanel/Mixpanel.h
@@ -620,6 +620,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)createAlias:(NSString *)alias forDistinctID:(NSString *)distinctID;
 
 - (NSString *)libVersion;
++ (NSString *)libVersion;
 
 
 #if !defined(MIXPANEL_APP_EXTENSION)

--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -942,6 +942,11 @@ static __unused NSString *MPURLEncode(NSString *s)
 
 - (NSString *)libVersion
 {
+    return [Mixpanel libVersion];
+}
+
++ (NSString *)libVersion
+{
     return VERSION;
 }
 


### PR DESCRIPTION
It is unable to get lib version before the instance is initialized

Now I'm using mixpanel like this:

``` swift

class Tracker {

    static let sharedInstance = Tracker()
    let mixpanel: Mixpanel 

    private init() {
        mixpanel = Mixpanel.sharedInstanceWithToken(AppKeys.mixpanelAppKey)
        mixpanel.registerSuperProperties(getEventSessionParameters())
        // other statement
    }

    static func getEventSessionParameters() -> [String : AnyObject] {    
        var results = [String : AnyObject]()
        results['Mixpanel Version'] = sharedInstance.mixpanel.libVersion
        // Other statement
        return results
    }
}
```
It will become something like an `endless loop`, so i need some way like that to get lib version.