### PR TITLE
Prevent negative $duration values

### DIFF
--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -525,7 +525,6 @@ static __unused NSString *MPURLEncode(NSString *s)
         MixpanelError(@"Mixpanel cannot time an empty event");
         return;
     }
-    
     dispatch_async(self.serialQueue, ^{
         self.timedEvents[event] = startTime;
     });

--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -519,12 +519,15 @@ static __unused NSString *MPURLEncode(NSString *s)
 
 - (void)timeEvent:(NSString *)event
 {
+    NSNumber *startTime = @([[NSDate date] timeIntervalSince1970]);
+    
     if (event == nil || [event length] == 0) {
         MixpanelError(@"Mixpanel cannot time an empty event");
         return;
     }
+    
     dispatch_async(self.serialQueue, ^{
-        self.timedEvents[event] = @([[NSDate date] timeIntervalSince1970]);
+        self.timedEvents[event] = startTime;
     });
 }
 


### PR DESCRIPTION
Fixes a race condition between timeEvent: and track: that leads to negative $duration values, due to the start time being captured asynchronously, while the event timestamp is recorded on the main thread. To prevent the start time from being evaluated after the event has been tracked, we simply capture the start time inside of timeEvent: before dispatching asynchronously.