### PR TITLE
Add flush after createAlias call

### DIFF
--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -379,6 +379,7 @@ static __unused NSString *MPURLEncode(NSString *s)
         return;
     }
     [self track:@"$create_alias" properties:@{ @"distinct_id": distinctID, @"alias": alias }];
+    [self flush];
 }
 
 - (void)track:(NSString *)event


### PR DESCRIPTION
Currently there is no flush after an alias is created within the iOS library. Without a flush, this leaves the potential for a race condition where an event could be stored with the wrong ID as the alias does not resolve in time. By forcing a flush, we can be sure the alias resolves before the next calls come in with the aliased distinct ID.

We currently do this in Android [here](https://github.com/mixpanel/mixpanel-android/blob/ca5c0d9e74217c6d5ce5e9afa58397c5d1346a14/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java#L360) and should add to iOS for parity.