### PR TITLE
fixed bug in removePushDeviceToken

### DIFF
--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -2006,7 +2006,7 @@ static void MixpanelReachabilityCallback(SCNetworkReachabilityRef target, SCNetw
 
 - (void)removePushDeviceToken
 {
-    NSDictionary *properties = @{ @"$properties": @"$ios_devices" };
+    NSDictionary *properties = @{ @"$properties": @[@"$ios_devices"] };
     [self addPeopleRecordToQueueWithAction:@"$unset" andProperties:properties];
 }
 


### PR DESCRIPTION
$unset expects a list of properties not a string