### PR TITLE
Added signalHandler to Mixpanel 

### DIFF
--- a/Mixpanel/MixpanelExceptionHandler.m
+++ b/Mixpanel/MixpanelExceptionHandler.m
@@ -10,6 +10,8 @@
 #import "Mixpanel.h"
 #import "MPLogger.h"
 
+#include <libkern/OSAtomic.h>
+
 @interface MixpanelExceptionHandler ()
 
 @property (nonatomic) NSUncaughtExceptionHandler *defaultExceptionHandler;
@@ -18,6 +20,19 @@
 @end
 
 @implementation MixpanelExceptionHandler
+
+static uint32_t volatile isAlreadyExceptionOccured =0;
+static int fatal_signals[] =
+{
+    SIGILL  ,   /* illegal instruction (not reset when caught) */
+    SIGTRAP ,   /* trace trap (not reset when caught) */
+    SIGABRT ,   /* abort() */
+    SIGFPE  ,   /* floating point exception */
+    SIGBUS  ,   /* bus error */
+    SIGSEGV ,   /* segmentation violation */
+    SIGSYS  ,   /* bad argument to system call */
+};
+static int n_fatal_signals = (sizeof(fatal_signals) / sizeof(fatal_signals[0]));
 
 + (instancetype)sharedHandler {
     static MixpanelExceptionHandler *gSharedHandler = nil;
@@ -33,37 +48,85 @@
     if (self) {
         // Create a hash table of weak pointers to mixpanel instances
         _mixpanelInstances = [NSHashTable weakObjectsHashTable];
-        
         // Save the existing exception handler
         _defaultExceptionHandler = NSGetUncaughtExceptionHandler();
         // Install our handler
         NSSetUncaughtExceptionHandler(&mp_handleUncaughtException);
+        // Install signal Handler
+        registerFatalSignals();
     }
     return self;
 }
 
 - (void)addMixpanelInstance:(Mixpanel *)instance {
     NSParameterAssert(instance != nil);
-    
     [self.mixpanelInstances addObject:instance];
 }
 
 static void mp_handleUncaughtException(NSException *exception) {
     MixpanelExceptionHandler *handler = [MixpanelExceptionHandler sharedHandler];
-    
-    // Archive the values for each Mixpanel instance
-    for (Mixpanel *instance in handler.mixpanelInstances) {
-        // Since we're storing the instances in a weak table, we need to ensure the pointer hasn't become nil
-        if (instance) {
-            [instance archive];
+    NSLog(@"!!!!!!");
+    if(isAlreadyExceptionOccured==0) {
+        OSAtomicOr32Barrier(1, &isAlreadyExceptionOccured);
+        // Archive the values for each Mixpanel instance
+        for (Mixpanel *instance in handler.mixpanelInstances) {
+            // Since we're storing the instances in a weak table, we need to ensure the pointer hasn't become nil
+            if (instance) {
+                [instance archive];
+            }
         }
+        
+        MixpanelError(@"Encountered an uncaught exception. All Mixpanel instances were archived.");
     }
-    
-    MixpanelError(@"Encountered an uncaught exception. All Mixpanel instances were archived.");
-    
     if (handler.defaultExceptionHandler) {
         // Ensure the existing handler gets called once we're finished
         handler.defaultExceptionHandler(exception);
+    }
+}
+
+static void mp_handleSignal(int sig, siginfo_t *info, void *context) {
+    unregisterFatalSignals();
+    MixpanelError(@"We received a signal: %d", sig);
+    NSLog(@"??????");
+
+    NSException* exception = [NSException
+                              exceptionWithName:@"UncaughtException"
+                              reason:
+                              [NSString stringWithFormat:
+                               NSLocalizedString(@"Signal %d was raised.", nil),
+                               sig]
+                              userInfo:
+                              [NSDictionary
+                               dictionaryWithObject:[NSNumber numberWithInt:sig]
+                               forKey:@"UncaughtExceptionSignalKey"]];
+    
+    mp_handleUncaughtException(exception);
+}
+
+static void registerFatalSignals() {
+    struct sigaction sa;
+    /* Configure action */
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_flags =  SA_SIGINFO | SA_ONSTACK;
+    sa.sa_sigaction = &mp_handleSignal;
+    sigemptyset(&sa.sa_mask);
+    /* Set new sigaction */
+    for (int i =0 ;i<n_fatal_signals; i++) {
+        if (sigaction(fatal_signals[i], &sa, NULL) != 0) {
+            //            int err = errno;
+            //            NSAssert(0,"Signal registration for %s failed: %s", strsignal(fatal_signals[i]), strerror(err));
+        }
+    }
+    
+}
+
+static void unregisterFatalSignals() {
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = SIG_DFL;
+    sigemptyset(&sa.sa_mask);
+    for (int i = 0; i < n_fatal_signals; i++) {
+        sigaction(fatal_signals[i], &sa, NULL);
     }
 }
 

--- a/Mixpanel/MixpanelExceptionHandler.m
+++ b/Mixpanel/MixpanelExceptionHandler.m
@@ -65,8 +65,7 @@ static int n_fatal_signals = (sizeof(fatal_signals) / sizeof(fatal_signals[0]));
 
 static void mp_handleUncaughtException(NSException *exception) {
     MixpanelExceptionHandler *handler = [MixpanelExceptionHandler sharedHandler];
-    NSLog(@"!!!!!!");
-    if(isAlreadyExceptionOccured==0) {
+    if (isAlreadyExceptionOccured==0) {
         OSAtomicOr32Barrier(1, &isAlreadyExceptionOccured);
         // Archive the values for each Mixpanel instance
         for (Mixpanel *instance in handler.mixpanelInstances) {
@@ -86,9 +85,6 @@ static void mp_handleUncaughtException(NSException *exception) {
 
 static void mp_handleSignal(int sig, siginfo_t *info, void *context) {
     unregisterFatalSignals();
-    MixpanelError(@"We received a signal: %d", sig);
-    NSLog(@"??????");
-
     NSException* exception = [NSException
                               exceptionWithName:@"UncaughtException"
                               reason:
@@ -99,33 +95,29 @@ static void mp_handleSignal(int sig, siginfo_t *info, void *context) {
                               [NSDictionary
                                dictionaryWithObject:[NSNumber numberWithInt:sig]
                                forKey:@"UncaughtExceptionSignalKey"]];
-    
     mp_handleUncaughtException(exception);
 }
 
 static void registerFatalSignals() {
+
     struct sigaction sa;
-    /* Configure action */
     memset(&sa, 0, sizeof(sa));
     sa.sa_flags =  SA_SIGINFO | SA_ONSTACK;
     sa.sa_sigaction = &mp_handleSignal;
     sigemptyset(&sa.sa_mask);
-    /* Set new sigaction */
-    for (int i =0 ;i<n_fatal_signals; i++) {
-        if (sigaction(fatal_signals[i], &sa, NULL) != 0) {
-            //            int err = errno;
-            //            NSAssert(0,"Signal registration for %s failed: %s", strsignal(fatal_signals[i]), strerror(err));
-        }
+    for (int i=0; i<n_fatal_signals; i++) {
+        sigaction(fatal_signals[i], &sa, NULL);
     }
     
 }
 
 static void unregisterFatalSignals() {
+    
     struct sigaction sa;
     memset(&sa, 0, sizeof(sa));
     sa.sa_handler = SIG_DFL;
     sigemptyset(&sa.sa_mask);
-    for (int i = 0; i < n_fatal_signals; i++) {
+    for (int i=0; i < n_fatal_signals; i++) {
         sigaction(fatal_signals[i], &sa, NULL);
     }
 }

--- a/Mixpanel/MixpanelExceptionHandler.m
+++ b/Mixpanel/MixpanelExceptionHandler.m
@@ -38,6 +38,7 @@ static int fatal_signals[] =
 static int n_fatal_signals = (sizeof(fatal_signals) / sizeof(fatal_signals[0]));
 
 + (void)initialize {
+    // Create mutable dictionary for save prev sigaction
     prevSigActions = [NSMutableDictionary dictionary];
 }
 + (instancetype)sharedHandler {
@@ -54,8 +55,6 @@ static int n_fatal_signals = (sizeof(fatal_signals) / sizeof(fatal_signals[0]));
     if (self) {
         // Create a hash table of weak pointers to mixpanel instances
         _mixpanelInstances = [NSHashTable weakObjectsHashTable];
-        // Create mutable dictionary for save prev sigaction
-        
         // Save the existing exception handler
         _defaultExceptionHandler = NSGetUncaughtExceptionHandler();
         // Install our handler


### PR DESCRIPTION
UncaughtExceptionHandler can not catch specific crash such as segmantation fault, floating point exception, bus error, etc.

In order to prevent to lose data from this crash, use signalHandler.

I added SignalHandler.
It prevent to lose data when app is crashed.

Thanks.