### PR TITLE
Remove team id from xcodeproj

### DIFF
--- a/Mixpanel.xcodeproj/project.pbxproj
+++ b/Mixpanel.xcodeproj/project.pbxproj
@@ -639,7 +639,6 @@
 				TargetAttributes = {
 					7C170C291A4A02F500D9E0F2 = {
 						CreatedOnToolsVersion = 6.1.1;
-						DevelopmentTeam = E8FVX7QLET;
 					};
 				};
 			};


### PR DESCRIPTION
Carthage build was failing because of that:

```
Code Sign error: No code signing identities found: No valid signing identities (i.e. certificate and private key pair) matching the team ID “E8FVX7QLET” were found.
```