### PR TITLE
Protect against a possible crash when an MPEventBinding constructor returns nil, likely due to renamed views or malformed JSON.

### DIFF
--- a/Mixpanel/MPDesignerEventBindingRequestMesssage.m
+++ b/Mixpanel/MPDesignerEventBindingRequestMesssage.m
@@ -29,7 +29,9 @@ NSString *const MPDesignerEventBindingRequestMessageType = @"event_binding_reque
     NSMutableArray *newBindings = [NSMutableArray array];
     for (NSDictionary *bindingInfo in bindingPayload) {
         MPEventBinding *binding = [MPEventBinding bindingWithJSONObject:bindingInfo];
-        [newBindings addObject:binding];
+        if (binding) {
+            [newBindings addObject:binding];
+        }
     }
 
     if (self.bindings) {


### PR DESCRIPTION
This resolves #431