### PR TITLE
Apply new variants / Turn off experiments when calling joinExperimentsWithCallback

### DIFF
--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -1387,7 +1387,7 @@ static void MixpanelReachabilityCallback(SCNetworkReachabilityRef target, SCNetw
             [allVariants unionSet:runningVariants];
 
             [restartVariants makeObjectsPerformSelector:NSSelectorFromString(@"restart")];
-            [toFinishVariants makeObjectsPerformSelector:NSSelectorFromString(@"finish")];
+            [toFinishVariants makeObjectsPerformSelector:NSSelectorFromString(@"stop")];
 
             NSArray *rawEventBindings = object[@"event_bindings"];
             NSMutableSet *parsedEventBindings = [NSMutableSet set];


### PR DESCRIPTION
Currently the SDK will check for new experiments via ```joinExperimentsWithCallback``` and process the updates received from Mixpanel servers. When a new variant is received or no variants are received, the running variant is [marked](https://github.com/mixpanel/mixpanel-iphone/blob/master/Mixpanel/Mixpanel.m#L1376-L1377) under the set ```toFinishVariants``` as it should be.

The issue is that for these finished variants, we call to [finish](https://github.com/mixpanel/mixpanel-iphone/blob/master/Mixpanel/MPVariant.m#L231-L233) which does not actually end the variant shown to the user. Instead, we should be calling [stop](https://github.com/mixpanel/mixpanel-iphone/blob/master/Mixpanel/MPVariant.m#L221-L229) to stop running this variant and allow the new changes from Mixpanel to be applied.

This resolves both cases highlighted in https://github.com/mixpanel/mixpanel-iphone/issues/429:

1. Receiving a new variant and applying the changes
2. Receiving no variant and turning the experiment off (reverting values to defaults)

Since the SDK will only check for new experiments when using ```joinExperimentsWithCallback```, updates from Mixpanel will only be applied when this method is called (which is the expected user behavior).