### PR TITLE
Guard transformValue in MPVariant

### DIFF
--- a/Mixpanel/MPVariant.m
+++ b/Mixpanel/MPVariant.m
@@ -556,6 +556,9 @@ static NSMapTable *originalCache;
                     for (NSUInteger i = 0; i < requiredArgs; i++) {
 
                         NSArray *argTuple = args[i];
+                        // Ensure we only send strings to the transform method
+                        if (![argTuple[1] isKindOfClass:[NSString class]]) continue;
+                        
                         id arg = transformValue(argTuple[0], argTuple[1]);
 
                         // Unpack NSValues to their base types.


### PR DESCRIPTION
Prevent `NSNull` from crashing `MPValueTransformer`. Resolves #434