### PR TITLE
Fix for watchOS integration

### DIFF
--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -1947,7 +1947,7 @@ static void MixpanelReachabilityCallback(SCNetworkReachabilityRef target, SCNetw
     NSString *messageType = [Mixpanel messageTypeForWatchSessionMessage:message];
     if (messageType) {
         if ([messageType isEqualToString:@"track"]) {
-            [[Mixpanel sharedInstance] track:message[@"event"] properties:message[@"properties"]];
+            [self track:message[@"event"] properties:message[@"properties"]];
         }
     }
 }
@@ -1957,7 +1957,7 @@ static void MixpanelReachabilityCallback(SCNetworkReachabilityRef target, SCNetw
     NSString *messageType = [Mixpanel messageTypeForWatchSessionMessage:message];
     if (messageType) {
         if ([messageType isEqualToString:@"track"]) {
-            [[Mixpanel sharedInstance] track:message[@"event"] properties:message[@"properties"]];
+            [self track:message[@"event"] properties:message[@"properties"]];
         }
         replyHandler(@{ @"success": @YES });
     } else {


### PR DESCRIPTION
Resolves watchOS integration when using more than one instance of the Mixpanel SDK. Resolves #449.