### PR TITLE
Crash fix for mp_important color

### DIFF
--- a/Mixpanel/UIImage+MPAverageColor.m
+++ b/Mixpanel/UIImage+MPAverageColor.m
@@ -29,9 +29,16 @@
     static const size_t kNumberOfRows = 124;
     static const size_t kNumberOfHexColors = 262144;
     
+    const size_t kImageWidth = CGImageGetWidth(self.CGImage);
+    const size_t kImageHeight = CGImageGetHeight(self.CGImage);
+    
     const size_t kBytesPerPixel = CGImageGetBitsPerPixel(self.CGImage) / 8;
     const size_t kBytesPerRow = CGImageGetBytesPerRow(self.CGImage);
-    const size_t kImageWidth = CGImageGetWidth(self.CGImage);
+    
+    // Don't calculate
+    if (kImageHeight < kImageStartRow + kNumberOfRows) {
+        return [self mp_averageColor];
+    }
     
     CFDataRef imageData = CGDataProviderCopyData(CGImageGetDataProvider(self.CGImage));
     const uint8_t *imageDataBuffer = CFDataGetBytePtr(imageData);

--- a/Mixpanel/UIImage+MPAverageColor.m
+++ b/Mixpanel/UIImage+MPAverageColor.m
@@ -8,59 +8,73 @@
 
 - (UIColor *)mp_averageColor
 {
-	CGSize size = {1, 1};
-	UIGraphicsBeginImageContext(size);
-	CGContextRef ctx = UIGraphicsGetCurrentContext();
-	CGContextSetInterpolationQuality(ctx, kCGInterpolationMedium);
-	[self drawInRect:(CGRect){.size = size} blendMode:kCGBlendModeCopy alpha:1];
-	uint8_t *data = CGBitmapContextGetData(ctx);
-	UIColor *color = [UIColor colorWithRed:data[2] / 255.0f
-									 green:data[1] / 255.0f
-									  blue:data[0] / 255.0f
-									 alpha:1];
-	UIGraphicsEndImageContext();
-	return color;
+    UIGraphicsBeginImageContextWithOptions(CGSizeMake(1, 1), YES, 0.f);
+    
+    CGContextRef ctx = UIGraphicsGetCurrentContext();
+    CGContextSetInterpolationQuality(ctx, kCGInterpolationMedium);
+    [self drawInRect:CGRectMake(0, 0, 1, 1) blendMode:kCGBlendModeCopy alpha:1];
+    
+    uint8_t *data = CGBitmapContextGetData(ctx);
+    UIColor *color = [UIColor colorWithRed:data[2] / 255.0f
+                                     green:data[1] / 255.0f
+                                      blue:data[0] / 255.0f
+                                     alpha:1];
+    UIGraphicsEndImageContext();
+    
+    return color;
 }
 
-- (UIColor *)mp_importantColor
-{
-    UIGraphicsBeginImageContext(self.size);
-    CGContextRef ctx = UIGraphicsGetCurrentContext();
-
-    [self drawInRect:(CGRect){.size = self.size} blendMode:kCGBlendModeCopy alpha:1];
-    uint8_t *data = CGBitmapContextGetData(ctx);
-
-    NSUInteger indexes = 262144;
-    char colorIndices[262144] = {0};
-
-    // only attempt to quantize the header
-    NSUInteger l = (NSUInteger) ceil(self.size.width * 124.0f);
-    for (NSUInteger i = 40 * 640; i < l; i++) {
-        uint8_t red = data[i * 4 + 2];
-        uint8_t green = data[i * 4 + 1];
-        uint8_t blue = data[i * 4 + 0];
-        NSInteger hexColor = (red >> 2) + ((green >> 2) << 6) + ((blue >> 2) << 12);
-
-        if (hexColor > 0 && hexColor < 2621443 && red + green + blue < 255 + 255 + 200 && red != blue && blue != green && green != red) {
-            colorIndices[hexColor]++;
+- (UIColor *)mp_importantColor {
+    static const size_t kImageStartRow = 40;
+    static const size_t kNumberOfRows = 124;
+    static const size_t kNumberOfHexColors = 262144;
+    
+    const size_t kBytesPerPixel = CGImageGetBitsPerPixel(self.CGImage) / 8;
+    const size_t kBytesPerRow = CGImageGetBytesPerRow(self.CGImage);
+    const size_t kImageWidth = CGImageGetWidth(self.CGImage);
+    
+    CFDataRef imageData = CGDataProviderCopyData(CGImageGetDataProvider(self.CGImage));
+    const uint8_t *imageDataBuffer = CFDataGetBytePtr(imageData);
+    
+    char colorIndices[kNumberOfHexColors] = {0};
+    
+    for (size_t rowIndex = kImageStartRow; rowIndex < kImageStartRow + kNumberOfRows; rowIndex++) {
+        const uint8_t *row = imageDataBuffer + kBytesPerRow * rowIndex;
+        for (size_t column = 0; column < kImageWidth; column++) {
+            const uint8_t red = row[0];
+            const uint8_t green = row[1];
+            const uint8_t blue = row[2];
+            
+            const int hexColor = (red >> 2) + ((green >> 2) << 6) + ((blue >> 2) << 12);
+            BOOL validHexColor = (0 < hexColor && hexColor < (int)kNumberOfHexColors - 1);
+            if (validHexColor) {
+                
+                BOOL notTooBright = (red + green + blue < 255 + 255 + 200);
+                if (notTooBright) {
+                    
+                    BOOL notGrayScale = (red != blue && blue != green && green != red);
+                    if (notGrayScale) {
+                        colorIndices[hexColor]++;
+                    }
+                }
+            }
+            row += kBytesPerPixel;
         }
     }
-
+    
     NSUInteger index = 0;
     char max = 0;
-    for (NSUInteger i = 0; i < indexes; i++) {
+    for (NSUInteger i = 0; i < kNumberOfHexColors; i++) {
         if (colorIndices[i] > max) {
             max = colorIndices[i];
             index = i;
         }
     }
-
-    UIColor *color = [UIColor colorWithRed:(((index & 63) << 2) + 3) / 255.0f
-									 green:(((index >> 4) & 252) + 3) / 255.0f
-									  blue:(((index >> 10) & 252) + 3) / 255.0f
-									 alpha:1];
-	UIGraphicsEndImageContext();
-	return color;
+    
+    return [UIColor colorWithRed:(((index & 63) << 2) + 3) / 255.0f
+                           green:(((index >> 4) & 252) + 3) / 255.0f
+                            blue:(((index >> 10) & 252) + 3) / 255.0f
+                           alpha:1];
 }
 
 @end


### PR DESCRIPTION
Fix mp_important color to be more safe, and leverage CoreGraphics instead of hard coded magic numbers.
Resolves #450