### PR TITLE
Expose notifications, update via API

### DIFF
--- a/Mixpanel/Mixpanel.h
+++ b/Mixpanel/Mixpanel.h
@@ -5,7 +5,7 @@
 #import <WatchConnectivity/WatchConnectivity.h>
 #endif
 
-@class    MixpanelPeople, MPSurvey;
+@class    MixpanelPeople, MPSurvey, MPNotification;
 @protocol MixpanelDelegate;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -175,6 +175,18 @@ NS_ASSUME_NONNULL_BEGIN
  If we haven't fetched the surveys yet, this will return nil.
  */
 @property (atomic, readonly) NSArray<MPSurvey *> *availableSurveys;
+
+/*!
+ @property
+ 
+ @abstract
+ Returns a list of available notifications. You can then call <code>showNotificationWithID:</code>
+ and pass in <code>notification.ID</code>
+ 
+ @discussion
+ If we haven't fetched the notifications yet, this will return nil.
+ */
+@property (atomic, readonly) NSArray<MPNotification *> *availableNotifications;
 
 /*!
  @property
@@ -617,6 +629,19 @@ NS_ASSUME_NONNULL_BEGIN
 
 /*!
  @method
+ 
+ @abstract
+ Checks for updates.
+ 
+ @discussion
+ Checks for updates for surveys, in-app notifications and variants ("tweaks"). This is useful
+ if you want to manually initialize Mixpanel, instead of relying on the provided library code
+ to check for updates when the app is being activated.
+ */
+- (void)checkForUpdatesWithCompletion:(void (^)(NSArray<MPSurvey *> *surveys, NSArray<MPNotification *> *notifications, NSSet *variants))completion;
+
+/*!
+ @method
 
  @abstract
  Writes current project info, including distinct ID, super properties and pending event
@@ -695,6 +720,38 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)showSurvey;
 
 #pragma mark - Mixpanel Notifications
+
+/*!
+ @method
+ 
+ @abstract
+ Tracks a notification.
+ 
+ @discussion
+ Sends an event to Mixpanel that includes the automatic properties associated
+ with the given notifications. In most cases this is not required, unless you're
+ not showing notifications using the library-provided views and activites.
+ 
+ @param notification The notification to track
+ @param event The name to use when the event is tracked.
+ */
+- (void)trackNotification:(MPNotification *)notification event:(NSString *) event;
+
+
+/*!
+ @method
+ 
+ @abstract
+ Marks a notification as seen.
+ 
+ @discussion
+ Tells MixPanel that you have handled a notification in cases where you are manually
+ dealing with your notifications. Note: If you do not acknowledge the notification you 
+ will receive it again each time you call getAvailableNotifications.
+ 
+ @param notification The notification to mark as shown.
+ */
+- (void)markNotificationShown:(MPNotification *)notification;
 
 /*!
  @method

--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -1491,6 +1491,15 @@ static void MixpanelReachabilityCallback(SCNetworkReachabilityRef target, SCNetw
     } useCache:NO];
 }
 
+- (void)checkForUpdatesWithCompletion:(void (^)(NSArray<MPSurvey *> *surveys, NSArray<MPNotification *> *notifications, NSSet *variants))completion
+{
+    [self checkForDecideResponseWithCompletion:^(NSArray *surveys, NSArray *notifications, NSSet *variants, NSSet *eventBindings) {
+        if (completion) {
+            completion(surveys, notifications, variants);
+        }
+    }];
+}
+
 #pragma mark - Surveys
 - (BOOL)isSurveyAvailable {
     return (self.surveys.count > 0);
@@ -1498,6 +1507,10 @@ static void MixpanelReachabilityCallback(SCNetworkReachabilityRef target, SCNetw
 
 - (NSArray<MPSurvey *> *)availableSurveys {
     return self.surveys;
+}
+
+- (NSArray<MPNotification *> *)availableNotifications {
+    return self.notifications;
 }
 
 - (void)presentSurveyWithRootViewController:(MPSurvey *)survey


### PR DESCRIPTION
Similar to how Survey's are exposed through the iOS SDK, this change
also adds the ability to retrieve all available notifications.

It also adds the ability to manually check for updated notifications,
surveys, etc. Depending on when the Mixpanel instance is initialized
(e.g. well after the app is activated) this may be necessary.