### PR TITLE
Make sure completion handler is called even when a decide check returns an error

### DIFF
--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -1337,7 +1337,7 @@ static void MixpanelReachabilityCallback(SCNetworkReachabilityRef target, SCNetw
             if (error) {
                 MixpanelError(@"%@ decide check http error: %@", self, error);
                 if (completion) {
-                    completion(nil,nil,nil,nil);
+                    completion(nil, nil, nil, nil);
                 }
                 return;
             }
@@ -1345,14 +1345,14 @@ static void MixpanelReachabilityCallback(SCNetworkReachabilityRef target, SCNetw
             if (error) {
                 MixpanelError(@"%@ decide check json error: %@, data: %@", self, error, [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]);
                 if (completion) {
-                    completion(nil,nil,nil,nil);
+                    completion(nil, nil, nil, nil);
                 }
                 return;
             }
             if (object[@"error"]) {
                 MixpanelDebug(@"%@ decide check api error: %@", self, object[@"error"]);
                 if (completion) {
-                    completion(nil,nil,nil,nil);
+                    completion(nil, nil, nil, nil);
                 }
                 return;
             }

--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -1336,15 +1336,24 @@ static void MixpanelReachabilityCallback(SCNetworkReachabilityRef target, SCNetw
             NSData *data = [NSURLConnection sendSynchronousRequest:request returningResponse:&urlResponse error:&error];
             if (error) {
                 MixpanelError(@"%@ decide check http error: %@", self, error);
+                if (completion) {
+                    completion(nil,nil,nil,nil);
+                }
                 return;
             }
             NSDictionary *object = [NSJSONSerialization JSONObjectWithData:data options:(NSJSONReadingOptions)0 error:&error];
             if (error) {
                 MixpanelError(@"%@ decide check json error: %@, data: %@", self, error, [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]);
+                if (completion) {
+                    completion(nil,nil,nil,nil);
+                }
                 return;
             }
             if (object[@"error"]) {
                 MixpanelDebug(@"%@ decide check api error: %@", self, object[@"error"]);
+                if (completion) {
+                    completion(nil,nil,nil,nil);
+                }
                 return;
             }
 


### PR DESCRIPTION
Currently, if we get an error back from decide in `checkForDecideResponseWithCompletion:completion useCache:` we log it and return without calling the completion handler. This prevents `joinExperimentsWithCallback:` from ever calling its callback block. This fix simply calls the completion handler (if it exists) with `nil` values in the event of a decide error.