### PR TITLE
Added Carthage/Build to the gitignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,7 @@ profile
 # AppCode
 .idea
 
+#Carthage
+Carthage/Build
+
 HelloMixpanel/build/


### PR DESCRIPTION
When this framework is added via carthage with the `--use-submodules` flag, it builds it in the mixpanel-iphone/Carthage/Build directory, marking this submodule as `dirty`. Adding `Carthage/Build` to the gitignore list fixes this :)