### PR TITLE
Fix track calls from Apple Watch

### DIFF
--- a/Mixpanel/Mixpanel+HostWatchOS.m
+++ b/Mixpanel/Mixpanel+HostWatchOS.m
@@ -14,7 +14,7 @@
 - (void)session:(WCSession *)session didReceiveMessage:(NSDictionary<NSString *, id> *)message {
     NSString *messageType = [Mixpanel messageTypeForWatchSessionMessage:message];
     if (messageType) {
-        if (NSStringFromSelector(@selector(track:properties:))) {
+        if ([messageType isEqualToString:NSStringFromSelector(@selector(track:properties:))]) {
             [self track:message[@"event"] properties:message[@"properties"]];
         }
     }

--- a/Mixpanel/Mixpanel+HostWatchOS.m
+++ b/Mixpanel/Mixpanel+HostWatchOS.m
@@ -14,7 +14,7 @@
 - (void)session:(WCSession *)session didReceiveMessage:(NSDictionary<NSString *, id> *)message {
     NSString *messageType = [Mixpanel messageTypeForWatchSessionMessage:message];
     if (messageType) {
-        if ([messageType isEqualToString:@"track:properties:"]) {
+        if (NSStringFromSelector(@selector(track:properties:))) {
             [self track:message[@"event"] properties:message[@"properties"]];
         }
     }

--- a/Mixpanel/Mixpanel+HostWatchOS.m
+++ b/Mixpanel/Mixpanel+HostWatchOS.m
@@ -14,7 +14,7 @@
 - (void)session:(WCSession *)session didReceiveMessage:(NSDictionary<NSString *, id> *)message {
     NSString *messageType = [Mixpanel messageTypeForWatchSessionMessage:message];
     if (messageType) {
-        if ([messageType isEqualToString:@"track"]) {
+        if ([messageType isEqualToString:@"track:properties:"]) {
             [self track:message[@"event"] properties:message[@"properties"]];
         }
     }


### PR DESCRIPTION
Currently the Apple Watch is looking for a ```messageType``` of ```track:``` when sending Mixpanel messages to the iPhone. Since the code for ```MixpanelWatchOS``` always sends the selector as ```track:properties:```, events are not being properly relayed back to the iPhone.

This PR is to look for the selector ```track:properties:``` from the Apple Watch and allow Mixpanel messages to be sent along to the iPhone.