### PR TITLE
Swizzling and codeless fixes

### DIFF
--- a/Mixpanel/MPEventBinding.m
+++ b/Mixpanel/MPEventBinding.m
@@ -108,4 +108,20 @@
     [aCoder encodeObject:NSStringFromClass(_swizzleClass) forKey:@"swizzleClass"];
 }
 
+- (BOOL)isEqual:(id)other
+{
+    if (other == self) {
+        return YES;
+    } else if (![other isKindOfClass:[MPEventBinding class]]) {
+        return NO;
+    } else {
+        return [self.eventName isEqual:((MPEventBinding *)other).eventName] && [self.path isEqual:((MPEventBinding *)other).path];
+    }
+}
+
+- (NSUInteger)hash
+{
+    return [self.eventName hash] ^ [self.path hash];
+}
+
 @end

--- a/Mixpanel/MPEventBinding.m
+++ b/Mixpanel/MPEventBinding.m
@@ -108,8 +108,7 @@
     [aCoder encodeObject:NSStringFromClass(_swizzleClass) forKey:@"swizzleClass"];
 }
 
-- (BOOL)isEqual:(id)other
-{
+- (BOOL)isEqual:(id)other {
     if (other == self) {
         return YES;
     } else if (![other isKindOfClass:[MPEventBinding class]]) {
@@ -119,8 +118,7 @@
     }
 }
 
-- (NSUInteger)hash
-{
+- (NSUInteger)hash {
     return [self.eventName hash] ^ [self.path hash];
 }
 

--- a/Mixpanel/MPObjectSelector.m
+++ b/Mixpanel/MPObjectSelector.m
@@ -202,6 +202,22 @@
     return self.string;
 }
 
+- (BOOL)isEqual:(id)other
+{
+    if (other == self) {
+        return YES;
+    } else if (![other isKindOfClass:[MPObjectSelector class]]) {
+        return NO;
+    } else {
+        return [self.string isEqual:((MPObjectSelector *)other).string];
+    }
+}
+
+- (NSUInteger)hash
+{
+    return [self.string hash];
+}
+
 @end
 
 @implementation MPObjectFilter

--- a/Mixpanel/MPObjectSelector.m
+++ b/Mixpanel/MPObjectSelector.m
@@ -202,8 +202,7 @@
     return self.string;
 }
 
-- (BOOL)isEqual:(id)other
-{
+- (BOOL)isEqual:(id)other {
     if (other == self) {
         return YES;
     } else if (![other isKindOfClass:[MPObjectSelector class]]) {
@@ -213,8 +212,7 @@
     }
 }
 
-- (NSUInteger)hash
-{
+- (NSUInteger)hash {
     return [self.string hash];
 }
 

--- a/Mixpanel/MPUIControlBinding.m
+++ b/Mixpanel/MPUIControlBinding.m
@@ -227,6 +227,8 @@
     [super encodeWithCoder:aCoder];
     [aCoder encodeObject:@(_controlEvent) forKey:@"controlEvent"];
     [aCoder encodeObject:@(_verifyEvent) forKey:@"verifyEvent"];
+    [aCoder encodeObject:_appliedTo forKey:@"appliedTo"];
+    [aCoder encodeObject:_verified forKey:@"verified"];
 }
 
 - (instancetype)initWithCoder:(NSCoder *)aDecoder
@@ -234,6 +236,8 @@
     if (self = [super initWithCoder:aDecoder]) {
         _controlEvent = [[aDecoder decodeObjectForKey:@"controlEvent"] unsignedIntegerValue];
         _verifyEvent = [[aDecoder decodeObjectForKey:@"verifyEvent"] unsignedIntegerValue];
+        _appliedTo = [aDecoder decodeObjectForKey:@"appliedTo"];
+        _verified = [aDecoder decodeObjectForKey:@"verified"];
     }
     return self;
 }

--- a/Mixpanel/MPUIControlBinding.m
+++ b/Mixpanel/MPUIControlBinding.m
@@ -238,8 +238,7 @@
     return self;
 }
 
-- (BOOL)isEqual:(id)other
-{
+- (BOOL)isEqual:(id)other {
     if (other == self) {
         return YES;
     } else if (![other isKindOfClass:[MPEventBinding class]]) {
@@ -249,8 +248,7 @@
     }
 }
 
-- (NSUInteger)hash
-{
+- (NSUInteger)hash {
     return [super hash] ^ self.controlEvent ^ self.verifyEvent;
 }
 

--- a/Mixpanel/MPUIControlBinding.m
+++ b/Mixpanel/MPUIControlBinding.m
@@ -238,4 +238,20 @@
     return self;
 }
 
+- (BOOL)isEqual:(id)other
+{
+    if (other == self) {
+        return YES;
+    } else if (![other isKindOfClass:[MPEventBinding class]]) {
+        return NO;
+    } else {
+        return [super isEqual:other] && self.controlEvent == ((MPUIControlBinding *)other).controlEvent && self.verifyEvent == ((MPUIControlBinding *)other).verifyEvent;
+    }
+}
+
+- (NSUInteger)hash
+{
+    return [super hash] ^ self.controlEvent ^ self.verifyEvent;
+}
+
 @end

--- a/Mixpanel/MPUITableViewBinding.m
+++ b/Mixpanel/MPUITableViewBinding.m
@@ -122,8 +122,7 @@
     return nil; // this view is not within a tableView
 }
 
-- (BOOL)isEqual:(id)other
-{
+- (BOOL)isEqual:(id)other {
     if (other == self) {
         return YES;
     } else if (![other isKindOfClass:[MPUITableViewBinding class]]) {
@@ -133,8 +132,7 @@
     }
 }
 
-- (NSUInteger)hash
-{
+- (NSUInteger)hash {
     return [super hash];
 }
 

--- a/Mixpanel/MPUITableViewBinding.m
+++ b/Mixpanel/MPUITableViewBinding.m
@@ -122,4 +122,20 @@
     return nil; // this view is not within a tableView
 }
 
+- (BOOL)isEqual:(id)other
+{
+    if (other == self) {
+        return YES;
+    } else if (![other isKindOfClass:[MPUITableViewBinding class]]) {
+        return NO;
+    } else {
+        return [super isEqual:other];
+    }
+}
+
+- (NSUInteger)hash
+{
+    return [super hash];
+}
+
 @end

--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -1469,7 +1469,6 @@ static void MixpanelReachabilityCallback(SCNetworkReachabilityRef target, SCNetw
             if (rawEventBindings && [rawEventBindings isKindOfClass:[NSArray class]]) {
                 for (id obj in rawEventBindings) {
                     MPEventBinding *binder = [MPEventBinding bindingWithJSONObject:obj];
-                    [binder execute];
                     if (binder) {
                         [parsedEventBindings addObject:binder];
                     }


### PR DESCRIPTION
NSHashSet didn't have a proper comparable, which caused all codeless bindings to keep accumulating with duplicates. Also this caused all codeless events to be unswizzled then re-swizzled all at once. 
Also, codeless events were tracked multiple times each time we got a decide response inside the same session