### PR TITLE
Refactor persistence

### DIFF
--- a/HelloMixpanel/HelloMixpanel.xcodeproj/project.pbxproj
+++ b/HelloMixpanel/HelloMixpanel.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		515B5A0B1CB6F96700A34060 /* Mixpanel.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 515B5A031CB6F95200A34060 /* Mixpanel.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		51D221061C599301003ECFB3 /* MixpanelDummy5XXHTTPConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 51D221051C599301003ECFB3 /* MixpanelDummy5XXHTTPConnection.m */; };
 		51D221091C5993C0003ECFB3 /* MixpanelDummyRetryAfterConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 51D221081C5993C0003ECFB3 /* MixpanelDummyRetryAfterConnection.m */; };
+		51FF031A1D0E738800DCD8F0 /* MPPersistenceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 51FF03191D0E738800DCD8F0 /* MPPersistenceTests.m */; };
 		8673E0F519C3B7090099AB66 /* MPTimingViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8673E0F419C3B7090099AB66 /* MPTimingViewController.m */; };
 		A71C6782FD423988AFBE61CC /* libPods-ABTestingTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F93B64201D77994D9569DA54 /* libPods-ABTestingTests.a */; };
 		A7BB224519183EB800EEDCCD /* ImageIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A7BB224419183EB800EEDCCD /* ImageIO.framework */; };
@@ -293,6 +294,7 @@
 		51D221051C599301003ECFB3 /* MixpanelDummy5XXHTTPConnection.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MixpanelDummy5XXHTTPConnection.m; sourceTree = "<group>"; };
 		51D221071C5993C0003ECFB3 /* MixpanelDummyRetryAfterConnection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MixpanelDummyRetryAfterConnection.h; sourceTree = "<group>"; };
 		51D221081C5993C0003ECFB3 /* MixpanelDummyRetryAfterConnection.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MixpanelDummyRetryAfterConnection.m; sourceTree = "<group>"; };
+		51FF03191D0E738800DCD8F0 /* MPPersistenceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPPersistenceTests.m; sourceTree = "<group>"; };
 		54804EDCB923F6CC7EF1F17A /* libPods-HelloMixpanelTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-HelloMixpanelTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		5E1876A34B6CEDB6F7F45538 /* Pods-ABTestingTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ABTestingTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-ABTestingTests/Pods-ABTestingTests.release.xcconfig"; sourceTree = "<group>"; };
 		83AEB5FB8EC0EA469A50BBB4 /* libPods-EventBindingTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-EventBindingTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -492,6 +494,7 @@
 			isa = PBXGroup;
 			children = (
 				2808F9BF1610EFE4005772B7 /* HelloMixpanelTests.m */,
+				51FF03191D0E738800DCD8F0 /* MPPersistenceTests.m */,
 				05C13E441818477600848D48 /* MixpanelDummyHTTPConnection.h */,
 				05C13E451818477600848D48 /* MixpanelDummyHTTPConnection.m */,
 				51D221041C599301003ECFB3 /* MixpanelDummy5XXHTTPConnection.h */,
@@ -654,7 +657,6 @@
 				2808F9AC1610EFE4005772B7 /* Sources */,
 				2808F9AD1610EFE4005772B7 /* Frameworks */,
 				2808F9AE1610EFE4005772B7 /* Resources */,
-				2808F9AF1610EFE4005772B7 /* ShellScript */,
 				6AD4F51E62F4794F46EC4F93 /* Embed Pods Frameworks */,
 				7EB546446E7626E6939A1F0F /* Copy Pods Resources */,
 			);
@@ -860,19 +862,6 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		2808F9AF1610EFE4005772B7 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# Run the unit tests in this test bundle.\n\"${SYSTEM_DEVELOPER_DIR}/Tools/RunUnitTests\"\n";
-		};
 		66D61E760A16CD4067275921 /* Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -1017,6 +1006,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				51FF031A1D0E738800DCD8F0 /* MPPersistenceTests.m in Sources */,
 				51D221061C599301003ECFB3 /* MixpanelDummy5XXHTTPConnection.m in Sources */,
 				05C13E461818477600848D48 /* MixpanelDummyHTTPConnection.m in Sources */,
 				51D221091C5993C0003ECFB3 /* MixpanelDummyRetryAfterConnection.m in Sources */,

--- a/HelloMixpanel/HelloMixpanel.xcodeproj/xcshareddata/xcschemes/HelloMixpanel.xcscheme
+++ b/HelloMixpanel/HelloMixpanel.xcodeproj/xcshareddata/xcschemes/HelloMixpanel.xcscheme
@@ -40,7 +40,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/HelloMixpanel/HelloMixpanelTests/MPPersistenceTests.m
+++ b/HelloMixpanel/HelloMixpanelTests/MPPersistenceTests.m
@@ -1,0 +1,218 @@
+//
+//  MPPersistenceTests.m
+//  HelloMixpanel
+//
+//  Created by Sam Green on 6/12/16.
+//  Copyright © 2016 Mixpanel. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "MPPersistence.h"
+
+@interface MPPersistence ()
+
+@property (nonatomic, copy) NSString *token;
+
++ (nonnull id)unarchiveOrDefaultFromPath:(NSString *)path asClass:(Class)class;
++ (id)unarchiveFromPath:(NSString *)path asClass:(Class)class;
+
++ (BOOL)archive:(id)object toPath:(NSString *)path;
+
+#pragma mark - Paths
+- (NSString *)pathForEvents;
+- (NSString *)pathForPeople;
+- (NSString *)pathForProperties;
+- (NSString *)pathForVariants;
+- (NSString *)pathForEventBindings;
+
++ (NSString *)pathFor:(NSString *)type withToken:(NSString *)token;
+
+@end
+
+@interface MPPersistenceTests : XCTestCase
+
+@property (nonatomic, strong) MPPersistence *persistence;
+
+@end
+
+static NSString *const kPersistenceTestToken = @"PersistenceUnitTestToken";
+static NSString *const kTestString = @"Test";
+
+@implementation MPPersistenceTests
+
+- (void)setUp {
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+    [super setUp];
+    self.persistence = [[MPPersistence alloc] initWithToken:kPersistenceTestToken];
+}
+
+#pragma mark - Serialization
+
+#pragma mark Archive
+- (void)testSerializeEventQueue {
+    NSMutableArray *events = [NSMutableArray arrayWithObjects:@1, @4, @7, nil];
+    [self.persistence archiveEventQueue:events];
+    
+    NSMutableArray *unarchivedEvents = [self.persistence unarchiveEventQueue];
+    XCTAssertEqualObjects(events, unarchivedEvents, @"Unarchived event queue did not match archived event queue.");
+}
+
+- (void)testSerializePeopleQueue {
+    NSMutableArray *people = [NSMutableArray arrayWithObjects:@"John", @"Jane", @"Juliet", nil];
+    [self.persistence archivePeopleQueue:people];
+    
+    NSMutableArray *unarchivedPeople = [self.persistence unarchivePeopleQueue];
+    XCTAssertEqualObjects(people, unarchivedPeople, @"Unarchived people queue did not match archived people queue.");
+}
+
+- (void)testSerializeProperties {
+    NSMutableDictionary *properties = [NSMutableDictionary dictionaryWithObjectsAndKeys:@1, @"Test", @"Value", @"Key", nil];
+    [self.persistence archiveProperties:properties];
+    
+    NSDictionary *unarchivedProperties = [self.persistence unarchiveProperties];
+    XCTAssertEqualObjects(properties, unarchivedProperties, @"Unarchived properties did not match archived properties.");
+}
+
+- (void)testSerializeVariants {
+    NSSet *variants = [NSSet setWithObjects:@1, @2, @3, nil];
+    [self.persistence archiveVariants:variants];
+    
+    NSSet *unarchivedVariants = [self.persistence unarchiveVariants];
+    XCTAssertEqualObjects(variants, unarchivedVariants, @"Unarchived variants did not match archived variants.");
+}
+
+- (void)testSerializeEventBindings {
+    NSSet *bindings = [NSSet setWithObjects:@4, @5, @9, nil];
+    [self.persistence archiveEventBindings:bindings];
+    
+    NSSet *unarchivedBindings = [self.persistence unarchiveEventBindings];
+    XCTAssertEqualObjects(bindings, unarchivedBindings, @"Unarchived event bindings did not match archived event bindings.");
+}
+
+- (void)testArchiveInvalidObject {
+    UIImage *image = [[UIImage alloc] init];
+    BOOL success = [MPPersistence archive:image toPath:@""];
+    XCTAssert(!success, @"Shouldn't happen; Successfully archived invalid object.");
+}
+
+- (void)testArchiveNilPath {
+    BOOL success = [MPPersistence archive:@"Test" toPath:nil];
+    XCTAssert(!success, @"Shouldn't happen; Successfully archived to nil path.");
+}
+
+- (void)testArchiveNilObject {
+    BOOL success = [MPPersistence archive:nil toPath:@""];
+    XCTAssert(!success, @"Shouldn't happen; Successfully archived nil object.");
+}
+
+- (void)testArchiveHelpers {
+    NSArray *libraries = NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES);
+    NSString *libraryPath = libraries.lastObject;
+    NSString *path = [libraryPath stringByAppendingPathComponent:@"test-archive.plist"];
+    
+    BOOL success = [MPPersistence archive:kTestString toPath:path];
+    XCTAssert(success, @"Failed to archived basic string to arbitrary path.");
+    
+    NSString *value = [MPPersistence unarchiveFromPath:path asClass:NSString.class];
+    XCTAssert([value isKindOfClass:NSString.class], @"Unarchived data was not the correct class.");
+    XCTAssertEqualObjects(kTestString, value, @"Unarchived data did not match archived value.");
+}
+
+- (void)testArchiveReturnsCorrectClasses {
+    NSMutableArray *data = [NSMutableArray arrayWithObject:kTestString];
+    
+    NSArray *libraries = NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES);
+    NSString *libraryPath = libraries.lastObject;
+    NSString *path = [libraryPath stringByAppendingPathComponent:@"test-mutable-archive.plist"];
+    
+    [MPPersistence archive:data toPath:path];
+    
+    NSMutableArray *mutableValue = [MPPersistence unarchiveFromPath:path asClass:NSMutableArray.class];
+    XCTAssert([mutableValue isKindOfClass:NSMutableArray.class]);
+    
+    NSArray *value = [MPPersistence unarchiveFromPath:path asClass:NSArray.class];
+    XCTAssert([value isKindOfClass:NSArray.class]);
+}
+
+#pragma mark Unarchive
+- (void)testUnarchiveExceptionHandling {
+    NSArray *libraries = NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES);
+    NSString *libraryPath = libraries.lastObject;
+    NSString *path = [libraryPath stringByAppendingPathComponent:@"test-invalid-archive.plist"];
+    
+    NSError *error = NULL;
+    [@"<xml><xml" writeToFile:path
+                   atomically:YES
+                     encoding:NSUTF8StringEncoding
+                        error:&error];
+    XCTAssert(error == NULL, @"Failed to write intentionally malformed archive.");
+    
+    id value = [MPPersistence unarchiveFromPath:path asClass:NSString.class];
+    XCTAssertNil(value);
+}
+
+- (void)testUnarchiveOrDefault {
+    NSArray *data = [MPPersistence unarchiveOrDefaultFromPath:@"" asClass:NSArray.class];
+    
+    XCTAssertNotNil(data);
+    XCTAssert([data isKindOfClass:NSArray.class]);
+    XCTAssert(data.count == 0);
+}
+
+#pragma mark - Path
+#pragma mark Accessors
+- (void)testPathForEvents {
+    NSString *path = [self.persistence pathForEvents];
+    NSString *filename = [path lastPathComponent];
+    XCTAssertEqualObjects(filename, @"mixpanel-PersistenceUnitTestToken-events.plist");
+}
+
+- (void)testPathForPeople {
+    NSString *path = [self.persistence pathForPeople];
+    NSString *filename = [path lastPathComponent];
+    XCTAssertEqualObjects(filename, @"mixpanel-PersistenceUnitTestToken-people.plist");
+}
+
+- (void)testPathForProperties {
+    NSString *path = [self.persistence pathForProperties];
+    NSString *filename = [path lastPathComponent];
+    XCTAssertEqualObjects(filename, @"mixpanel-PersistenceUnitTestToken-properties.plist");
+}
+
+- (void)testPathForEventBindings {
+    NSString *path = [self.persistence pathForEventBindings];
+    NSString *filename = [path lastPathComponent];
+    XCTAssertEqualObjects(filename, @"mixpanel-PersistenceUnitTestToken-event_bindings.plist");
+}
+
+- (void)testPathForVariants {
+    NSString *path = [self.persistence pathForVariants];
+    NSString *filename = [path lastPathComponent];
+    XCTAssertEqualObjects(filename, @"mixpanel-PersistenceUnitTestToken-variants.plist");
+}
+
+//
+// This caught a copy and paste error, and ensures we're not writing different data to
+// the same file in two places.
+//
+- (void)testPathsAreUnique {
+    NSArray *paths = @[ [self.persistence pathForEvents], [self.persistence pathForPeople],
+                        [self.persistence pathForProperties], [self.persistence pathForEventBindings],
+                        [self.persistence pathForVariants] ];
+    NSSet *pathSet = [NSSet setWithArray:paths];
+    XCTAssert(paths.count == pathSet.count, @"Paths are not unique.");
+}
+
+//
+// Path is uniquely named based on token and type of path
+//
+- (void)testPathBuilder {
+    NSString *path = [MPPersistence pathFor:@"TestObject" withToken:kPersistenceTestToken];
+    NSString *filename = [path lastPathComponent];
+    XCTAssertEqualObjects(filename, @"mixpanel-PersistenceUnitTestToken-TestObject.plist");
+    
+    NSString *parentDirectory = path.pathComponents[path.pathComponents.count - 2];
+    XCTAssertEqualObjects(parentDirectory, @"Library");
+}
+
+@end

--- a/Mixpanel.xcodeproj/project.pbxproj
+++ b/Mixpanel.xcodeproj/project.pbxproj
@@ -1319,6 +1319,12 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				GCC_PREFIX_HEADER = "";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"MIXPANEL_DEBUG=1",
+					"DEBUG=1",
+					"$(inherited)",
+					"MIXPANEL_ERROR=1",
+				);
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;

--- a/Mixpanel.xcodeproj/project.pbxproj
+++ b/Mixpanel.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		37F9F7F31C2B8BFC00783DDB /* MPFoundation.h in Headers */ = {isa = PBXBuildFile; fileRef = 37F9F7F11C2B8BFC00783DDB /* MPFoundation.h */; };
+		510D47E51D0D461400F637F4 /* MPPersistence.h in Headers */ = {isa = PBXBuildFile; fileRef = 510D47E31D0D461400F637F4 /* MPPersistence.h */; };
+		510D47E61D0D461400F637F4 /* MPPersistence.m in Sources */ = {isa = PBXBuildFile; fileRef = 510D47E41D0D461400F637F4 /* MPPersistence.m */; };
 		511FC3591C2B74BD00DC4796 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7C170D451A4A05A000D9E0F2 /* Foundation.framework */; };
 		511FC35B1C2B74BD00DC4796 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7C170D411A4A059400D9E0F2 /* UIKit.framework */; };
 		511FC35D1C2B74BD00DC4796 /* MixpanelWatchOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 511FC30A1C2B739B00DC4796 /* MixpanelWatchOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -190,6 +192,8 @@
 
 /* Begin PBXFileReference section */
 		37F9F7F11C2B8BFC00783DDB /* MPFoundation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MPFoundation.h; path = Mixpanel/MPFoundation.h; sourceTree = "<group>"; };
+		510D47E31D0D461400F637F4 /* MPPersistence.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MPPersistence.h; sourceTree = "<group>"; };
+		510D47E41D0D461400F637F4 /* MPPersistence.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPPersistence.m; sourceTree = "<group>"; };
 		511FC3091C2B739B00DC4796 /* MixpanelWatchOS.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MixpanelWatchOS.m; sourceTree = "<group>"; };
 		511FC30A1C2B739B00DC4796 /* MixpanelWatchOS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MixpanelWatchOS.h; sourceTree = "<group>"; };
 		511FC39D1C2B74BD00DC4796 /* Mixpanel.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Mixpanel.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -405,6 +409,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		510D47E21D0D45D700F637F4 /* Core */ = {
+			isa = PBXGroup;
+			children = (
+				510D47E31D0D461400F637F4 /* MPPersistence.h */,
+				510D47E41D0D461400F637F4 /* MPPersistence.m */,
+			);
+			name = Core;
+			sourceTree = "<group>";
+		};
 		514733C61CD7D6EC0098B23A /* Images */ = {
 			isa = PBXGroup;
 			children = (
@@ -734,6 +747,7 @@
 				7C170C4C1A4A035F00D9E0F2 /* Mixpanel.m */,
 				514733BB1CD7CCDB0098B23A /* MPResources.h */,
 				514733BC1CD7CCDB0098B23A /* MPResources.m */,
+				510D47E21D0D45D700F637F4 /* Core */,
 				515B5A1A1CB6FC4000A34060 /* Designer Support */,
 				515B5A161CB6FBAC00A34060 /* Surveys */,
 				515B5A151CB6FBA500A34060 /* Notifications */,
@@ -824,6 +838,7 @@
 				7C170D091A4A035F00D9E0F2 /* MPObjectSerializer.h in Headers */,
 				7C170CF81A4A035F00D9E0F2 /* MPEnumDescription.h in Headers */,
 				7C170D311A4A035F00D9E0F2 /* MPVariant.h in Headers */,
+				510D47E51D0D461400F637F4 /* MPPersistence.h in Headers */,
 				7C170D101A4A035F00D9E0F2 /* MPPropertyDescription.h in Headers */,
 				37F9F7F31C2B8BFC00783DDB /* MPFoundation.h in Headers */,
 				513583971BD1BE50008EEDF1 /* UIView+MPHelpers.h in Headers */,
@@ -1051,6 +1066,7 @@
 				7C170D2F1A4A035F00D9E0F2 /* MPUITableViewBinding.m in Sources */,
 				7C170CCF1A4A035F00D9E0F2 /* MPABTestDesignerChangeResponseMessage.m in Sources */,
 				7C170CFE1A4A035F00D9E0F2 /* MPNotification.m in Sources */,
+				510D47E61D0D461400F637F4 /* MPPersistence.m in Sources */,
 				7C170CFB1A4A035F00D9E0F2 /* MPEventBinding.m in Sources */,
 				7C170CE71A4A035F00D9E0F2 /* MPBOOLToNSNumberValueTransformer.m in Sources */,
 				7C170CD91A4A035F00D9E0F2 /* MPABTestDesignerDeviceInfoResponseMessage.m in Sources */,

--- a/Mixpanel/MPPersistence.h
+++ b/Mixpanel/MPPersistence.h
@@ -1,0 +1,29 @@
+//
+//  MPPersistence.h
+//  Mixpanel
+//
+//  Created by Sam Green on 6/12/16.
+//  Copyright © 2016 Mixpanel. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface MPPersistence : NSObject
+
+- (instancetype)initWithToken:(NSString *)token;
+
+#pragma mark - Archive
+- (void)archiveEvents:(NSMutableArray *)events;
+- (void)archivePeople:(NSMutableArray *)people;
+- (void)archiveProperties:(NSMutableDictionary *)properties;
+- (void)archiveVariants:(NSSet *)variants;
+- (void)archiveEventBindings:(NSSet *)eventBindings;
+
+#pragma mark - Unarchive
+- (NSMutableArray *)unarchiveEvents;
+- (NSMutableArray *)unarchivePeople;
+- (NSMutableDictionary *)unarchiveProperties;
+- (NSSet *)unarchiveVariants;
+- (NSSet *)unarchiveEventBindings;
+
+@end

--- a/Mixpanel/MPPersistence.h
+++ b/Mixpanel/MPPersistence.h
@@ -13,16 +13,16 @@
 - (instancetype)initWithToken:(NSString *)token;
 
 #pragma mark - Archive
-- (void)archiveEvents:(NSMutableArray *)events;
-- (void)archivePeople:(NSMutableArray *)people;
+- (void)archiveEventQueue:(NSMutableArray *)events;
+- (void)archivePeopleQueue:(NSMutableArray *)people;
 - (void)archiveProperties:(NSMutableDictionary *)properties;
 - (void)archiveVariants:(NSSet *)variants;
 - (void)archiveEventBindings:(NSSet *)eventBindings;
 
 #pragma mark - Unarchive
-- (NSMutableArray *)unarchiveEvents;
-- (NSMutableArray *)unarchivePeople;
-- (NSMutableDictionary *)unarchiveProperties;
+- (NSMutableArray *)unarchiveEventQueue;
+- (NSMutableArray *)unarchivePeopleQueue;
+- (NSDictionary *)unarchiveProperties;
 - (NSSet *)unarchiveVariants;
 - (NSSet *)unarchiveEventBindings;
 

--- a/Mixpanel/MPPersistence.m
+++ b/Mixpanel/MPPersistence.m
@@ -1,0 +1,155 @@
+//
+//  MPPersistence.m
+//  Mixpanel
+//
+//  Created by Sam Green on 6/12/16.
+//  Copyright © 2016 Mixpanel. All rights reserved.
+//
+
+#import "MPPersistence.h"
+#import "MPLogger.h"
+#import "Mixpanel.h"
+
+@interface MPPersistence ()
+
+@property (nonatomic, copy) NSString *token;
+
+@end
+
+@implementation MPPersistence
+
+- (instancetype)initWithToken:(NSString *)token {
+    self = [super init];
+    if (self) {
+        self.token = token;
+    }
+    return self;
+}
+
+#pragma mark - Archive
+- (void)archiveEvents:(NSMutableArray *)events {
+    NSString *path = [self pathForEvents];
+    MixpanelDebug(@"%@ archiving events data to %@: %@", self.token, path, events);
+    if (![MPPersistence archive:events toPath:path]) {
+        MixpanelError(@"%@ unable to archive events data", self.token);
+    }
+}
+
+- (void)archivePeople:(NSMutableArray *)people {
+    NSString *path = [self pathForPeople];
+    MixpanelDebug(@"%@ archiving people data to %@: %@", self.token, path, people);
+    if (![MPPersistence archive:people toPath:path]) {
+        MixpanelError(@"%@ unable to archive people data", self.token);
+    }
+}
+
+- (void)archiveProperties:(NSMutableDictionary *)properties {
+    NSString *path = [self pathForProperties];
+    MixpanelDebug(@"%@ archiving properties to %@: %@", self.token, path, properties);
+    if (![MPPersistence archive:properties toPath:path]) {
+        MixpanelError(@"%@ unable to archive properties", self.token);
+    }
+}
+
+- (void)archiveVariants:(NSSet *)variants {
+    NSString *path = [self pathForVariants];
+    MixpanelDebug(@"%@ archiving variants to %@: %@", self.token, path, variants);
+    if (![MPPersistence archive:variants toPath:path]) {
+        MixpanelError(@"%@ unable to archive variants data", self.token);
+    }
+}
+
+- (void)archiveEventBindings:(NSSet *)eventBindings {
+    NSString *path = [self pathForEventBindings];
+    MixpanelDebug(@"%@ archiving event bindings to %@: %@", self.token, path, eventBindings);
+    if (![MPPersistence archive:eventBindings toPath:path]) {
+        MixpanelError(@"%@ unable to archive variants data", self.token);
+    }
+}
+
++ (BOOL)archive:(id)object toPath:(NSString *)path {
+    if (![NSKeyedArchiver archiveRootObject:object toFile:path]) {
+        // TODO: Handle failure
+        return NO;
+    }
+    return YES;
+}
+
+#pragma mark - Unarchive
+- (NSMutableArray *)unarchiveEvents {
+    return [MPPersistence unarchiveOrDefaultFromPath:[self pathForEvents]
+                                             asClass:[NSMutableArray class]];
+}
+
+- (NSMutableArray *)unarchivePeople {
+    return [MPPersistence unarchiveOrDefaultFromPath:[self pathForPeople]
+                                             asClass:[NSMutableArray class]];
+}
+
+- (NSMutableDictionary *)unarchiveProperties {
+    return [MPPersistence unarchiveFromPath:[self pathForProperties]
+                                    asClass:[NSMutableDictionary class]];
+}
+
+- (NSSet *)unarchiveVariants {
+    return [MPPersistence unarchiveFromPath:[self pathForVariants]
+                                    asClass:[NSSet class]];
+}
+
+- (NSSet *)unarchiveEventBindings {
+    return [MPPersistence unarchiveFromPath:[self pathForEventBindings]
+                                    asClass:[NSSet class]];
+}
+
++ (nonnull id)unarchiveOrDefaultFromPath:(NSString *)path asClass:(Class)class {
+    return [self unarchiveFromPath:path asClass:class] ?: [class new];
+}
+
++ (id)unarchiveFromPath:(NSString *)path asClass:(Class)class {
+    @try {
+        id unarchivedData = [NSKeyedUnarchiver unarchiveObjectWithFile:path];
+        // this check is inside the try-catch as the unarchivedData may be a non-NSObject,
+        // not responding to `isKindOfClass:` or `respondsToSelector:`
+        if ([unarchivedData isKindOfClass:class]) {
+            return unarchivedData;
+        }
+    }
+    @catch (NSException *exception) {
+        // Remove the (possibly) corrupt data from the disk
+        NSError *error = NULL;
+        BOOL removed = [[NSFileManager defaultManager] removeItemAtPath:path error:&error];
+        if (!removed || error) {
+            // TODO: Handle Failure
+        }
+    }
+    return nil;
+}
+
+#pragma mark - Paths
+- (NSString *)pathForEvents {
+    return [MPPersistence pathFor:@"events" withToken:self.token];
+}
+
+- (NSString *)pathForPeople {
+    return [MPPersistence pathFor:@"people" withToken:self.token];
+}
+
+- (NSString *)pathForProperties {
+    return [MPPersistence pathFor:@"properties" withToken:self.token];
+}
+
+- (NSString *)pathForVariants {
+    return [MPPersistence pathFor:@"variants" withToken:self.token];
+}
+
+- (NSString *)pathForEventBindings {
+    return [MPPersistence pathFor:@"event_bindings" withToken:self.token];
+}
+
++ (NSString *)pathFor:(NSString *)type withToken:(NSString *)token {
+    NSArray *libraries = NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES);
+    NSString *filename = [NSString stringWithFormat:@"mixpanel-%@-%@.plist", token, type];
+    return [libraries.lastObject stringByAppendingPathComponent:filename];
+}
+
+@end

--- a/Mixpanel/MPPersistence.m
+++ b/Mixpanel/MPPersistence.m
@@ -69,7 +69,7 @@
 
 + (BOOL)archive:(id)object toPath:(NSString *)path {
     if (![NSKeyedArchiver archiveRootObject:object toFile:path]) {
-        // TODO: Handle failure
+        MixpanelError(@"Unable to archive class %@ to path %@", object, path);
         return NO;
     }
     return YES;
@@ -106,14 +106,17 @@
 
 + (id)unarchiveFromPath:(NSString *)path asClass:(Class)class {
     @try {
+        MixpanelDebug(@"Attempting to unarchive %@ Class stored at path: %@", class, path);
         id unarchivedData = [NSKeyedUnarchiver unarchiveObjectWithFile:path];
         // this check is inside the try-catch as the unarchivedData may be a non-NSObject,
         // not responding to `isKindOfClass:` or `respondsToSelector:`
         if ([unarchivedData isKindOfClass:class]) {
+            MixpanelDebug(@"Unarchived %@ Class successfully.", class);
             return unarchivedData;
         }
     }
     @catch (NSException *exception) {
+        MixpanelError(@"Failed to unarchive %@ Class at path: %@. %@-Details: %@", class, path, exception.name, exception.reason);
         // Remove the (possibly) corrupt data from the disk
         NSError *error = NULL;
         BOOL removed = [[NSFileManager defaultManager] removeItemAtPath:path error:&error];

--- a/Mixpanel/MPPersistence.m
+++ b/Mixpanel/MPPersistence.m
@@ -27,7 +27,7 @@
 }
 
 #pragma mark - Archive
-- (void)archiveEvents:(NSMutableArray *)events {
+- (void)archiveEventQueue:(NSMutableArray *)events {
     NSString *path = [self pathForEvents];
     MixpanelDebug(@"%@ archiving events data to %@: %@", self.token, path, events);
     if (![MPPersistence archive:events toPath:path]) {
@@ -35,7 +35,7 @@
     }
 }
 
-- (void)archivePeople:(NSMutableArray *)people {
+- (void)archivePeopleQueue:(NSMutableArray *)people {
     NSString *path = [self pathForPeople];
     MixpanelDebug(@"%@ archiving people data to %@: %@", self.token, path, people);
     if (![MPPersistence archive:people toPath:path]) {
@@ -76,19 +76,18 @@
 }
 
 #pragma mark - Unarchive
-- (NSMutableArray *)unarchiveEvents {
+- (NSMutableArray *)unarchiveEventQueue {
     return [MPPersistence unarchiveOrDefaultFromPath:[self pathForEvents]
                                              asClass:[NSMutableArray class]];
 }
 
-- (NSMutableArray *)unarchivePeople {
+- (NSMutableArray *)unarchivePeopleQueue {
     return [MPPersistence unarchiveOrDefaultFromPath:[self pathForPeople]
                                              asClass:[NSMutableArray class]];
 }
-
-- (NSMutableDictionary *)unarchiveProperties {
+- (NSDictionary *)unarchiveProperties {
     return [MPPersistence unarchiveFromPath:[self pathForProperties]
-                                    asClass:[NSMutableDictionary class]];
+                                    asClass:[NSDictionary class]];
 }
 
 - (NSSet *)unarchiveVariants {
@@ -119,7 +118,7 @@
         NSError *error = NULL;
         BOOL removed = [[NSFileManager defaultManager] removeItemAtPath:path error:&error];
         if (!removed || error) {
-            // TODO: Handle Failure
+            MixpanelError(@"Failure load file at %@. File was removed. Details: %@", path, error.localizedDescription);
         }
     }
     return nil;


### PR DESCRIPTION
This migrates all file handling and persistence functionality in to an `MPPersistence` helper. This alos adds a new test suite focused exclusively on persistence.

Tests Status:
![screen shot 2016-06-13 at 4 26 02 pm](https://cloud.githubusercontent.com/assets/276118/16026451/9fd21bee-3183-11e6-8ac7-9d04cb1db5fa.png)

Code Coverage Report:
![screen shot 2016-06-13 at 4 26 26 pm](https://cloud.githubusercontent.com/assets/276118/16026455/a3cafb62-3183-11e6-8b4e-864598bb6164.png)
