### PR TITLE
Ignored the unused result warning

### DIFF
--- a/Mixpanel/MPWebSocket.m
+++ b/Mixpanel/MPWebSocket.m
@@ -521,7 +521,12 @@ static __strong NSData *CRLFCRLF;
     CFHTTPMessageSetHeaderFieldValue(request, CFSTR("Host"), (__bridge CFStringRef)(_url.port ? [NSString stringWithFormat:@"%@:%@", _url.host, _url.port] : _url.host));
 
     NSMutableData *keyBytes = [[NSMutableData alloc] initWithLength:16];
-    SecRandomCopyBytes(kSecRandomDefault, keyBytes.length, keyBytes.mutableBytes);
+
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wunused-result"
+        SecRandomCopyBytes(kSecRandomDefault, keyBytes.length, keyBytes.mutableBytes);
+    #pragma clang diagnostic pop
+
     _secKey = [keyBytes mp_base64EncodedString];
     assert([_secKey length] == 24);
 
@@ -1392,7 +1397,12 @@ static const size_t MPFrameHeaderOverhead = 32;
         }
     } else {
         uint8_t *mask_key = frame_buffer + frame_buffer_size;
-        SecRandomCopyBytes(kSecRandomDefault, sizeof(uint32_t), mask_key);
+
+        #pragma clang diagnostic push
+        #pragma clang diagnostic ignored "-Wunused-result"
+            SecRandomCopyBytes(kSecRandomDefault, sizeof(uint32_t), mask_key);
+        #pragma clang diagnostic pop
+
         frame_buffer_size += sizeof(uint32_t);
 
         // TODO: could probably optimize this with SIMD


### PR DESCRIPTION
Background: When `mixpanel-iphone` is integrated using a `git submodule` to a project that has `Threat warnings as error` enabled, this triggers a compile error. 

Solution: Disabled the warning using the `clang diagnostic ignored "-Wunused-result"`