### PR TITLE
Handled warning in Xcode 8 and iOS 10

### DIFF
--- a/Mixpanel/MPWebSocket.m
+++ b/Mixpanel/MPWebSocket.m
@@ -521,7 +521,10 @@ static __strong NSData *CRLFCRLF;
     CFHTTPMessageSetHeaderFieldValue(request, CFSTR("Host"), (__bridge CFStringRef)(_url.port ? [NSString stringWithFormat:@"%@:%@", _url.host, _url.port] : _url.host));
 
     NSMutableData *keyBytes = [[NSMutableData alloc] initWithLength:16];
-    SecRandomCopyBytes(kSecRandomDefault, keyBytes.length, keyBytes.mutableBytes);
+    int copyResult = SecRandomCopyBytes(kSecRandomDefault, keyBytes.length, keyBytes.mutableBytes);
+    if (copyResult != 0) {
+        [self _failWithError:[NSError errorWithDomain:MPWebSocketErrorDomain code:errno userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat:@"SecRandomCopyBytes failed"]}]];
+    }
     _secKey = [keyBytes mp_base64EncodedString];
     assert(_secKey.length == 24);
 
@@ -1390,7 +1393,10 @@ static const size_t MPFrameHeaderOverhead = 32;
         }
     } else {
         uint8_t *mask_key = frame_buffer + frame_buffer_size;
-        SecRandomCopyBytes(kSecRandomDefault, sizeof(uint32_t), mask_key);
+        int copyResult = SecRandomCopyBytes(kSecRandomDefault, sizeof(uint32_t), mask_key);
+        if (copyResult != 0) {
+            [self _failWithError:[NSError errorWithDomain:MPWebSocketErrorDomain code:errno userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat:@"SecRandomCopyBytes failed"]}]];
+        }
         frame_buffer_size += sizeof(uint32_t);
 
         // TODO: could probably optimize this with SIMD


### PR DESCRIPTION
The function SecRandomCopyBytes now requires us to handle its return value.