### PR TITLE
First pass at better URL encoding

### DIFF
--- a/HelloMixpanel/HelloMixpanel.xcodeproj/project.pbxproj
+++ b/HelloMixpanel/HelloMixpanel.xcodeproj/project.pbxproj
@@ -297,7 +297,6 @@
 		5115A0E21B4F4DF700787217 /* huge_checkerboard.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = huge_checkerboard.jpg; sourceTree = SOURCE_ROOT; };
 		5115A0E31B4F4DF700787217 /* small_checkerboard.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = small_checkerboard.jpg; sourceTree = SOURCE_ROOT; };
 		515B59FC1CB6F95200A34060 /* Mixpanel.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Mixpanel.xcodeproj; path = ../Mixpanel.xcodeproj; sourceTree = "<group>"; };
-		517ABB6C1D14ADCD00FF8061 /* MPNetworkTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MPNetworkTests.h; sourceTree = "<group>"; };
 		517ABB6D1D14ADCD00FF8061 /* MPNetworkTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPNetworkTests.m; sourceTree = "<group>"; };
 		518010151D11CEA300C5F3EA /* Nocilla.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Nocilla.framework; sourceTree = "<group>"; };
 		51D96E7B1D120A75001F622D /* TestConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TestConstants.h; sourceTree = "<group>"; };
@@ -490,7 +489,6 @@
 				51D96E801D120D3E001F622D /* MPNotificationTests.m */,
 				51D96E7E1D120D2A001F622D /* MPSurveyTests.m */,
 				51D96E821D120D4F001F622D /* MixpanelPeopleTests.m */,
-				517ABB6C1D14ADCD00FF8061 /* MPNetworkTests.h */,
 				517ABB6D1D14ADCD00FF8061 /* MPNetworkTests.m */,
 				2808F9B91610EFE4005772B7 /* Supporting Files */,
 			);

--- a/HelloMixpanel/HelloMixpanelTests/MPNetworkTests.h
+++ b/HelloMixpanel/HelloMixpanelTests/MPNetworkTests.h
@@ -14,24 +14,3 @@
 @property (nonatomic, strong) MPNetwork *network;
 
 @end
-
-#pragma mark - Testable Interface
-@interface MPNetwork ()
-
-@property (nonatomic, strong) NSURL *serverURL;
-
-@property (nonatomic) NSTimeInterval requestsDisabledUntilTime;
-@property (nonatomic) NSUInteger consecutiveFailures;
-
-- (BOOL)handleNetworkResponse:(NSHTTPURLResponse *)response withError:(NSError *)error;
-- (NSURLRequest *)requestForEndpoint:(NSString *)endpoint withBody:(NSString *)body;
-
-+ (NSTimeInterval)calculateBackOffTimeFromFailures:(NSUInteger)failureCount;
-+ (NSTimeInterval)parseRetryAfterTime:(NSHTTPURLResponse *)response;
-+ (BOOL)parseHTTPFailure:(NSHTTPURLResponse *)response withError:(NSError *)error;
-
-+ (NSString *)encodeArrayForAPI:(NSArray *)array;
-+ (NSData *)encodeArrayAsJSONData:(NSArray *)array;
-+ (NSString *)encodeJSONDataAsBase64:(NSData *)data;
-
-@end

--- a/HelloMixpanel/HelloMixpanelTests/MPNetworkTests.m
+++ b/HelloMixpanel/HelloMixpanelTests/MPNetworkTests.m
@@ -36,9 +36,7 @@
 #pragma mark - Request Creation
 - (void)testRequestForTrackEndpoint {
     NSString *body = @"track test body";
-    NSURLRequest *request = [self.network requestForEndpoint:@"/track/"
-                                                byHTTPMethod:@"POST"
-                                                     andBody:body];
+    NSURLRequest *request = [self.network buildPostRequestForEndpoint:MPNetworkEndpointTrack andBody:body];
     XCTAssertEqualObjects(request.URL, [NSURL URLWithString:@"http://localhost:31337/track/"]);
     XCTAssert([request.HTTPMethod isEqualToString:@"POST"]);
     XCTAssertEqualObjects(request.HTTPBody, [body dataUsingEncoding:NSUTF8StringEncoding]);
@@ -47,9 +45,7 @@
 
 - (void)testRequestForPeopleEndpoint {
     NSString *body = @"engage test body";
-    NSURLRequest *request = [self.network requestForEndpoint:@"/engage/"
-                                                byHTTPMethod:@"POST"
-                                                     andBody:body];
+    NSURLRequest *request = [self.network buildPostRequestForEndpoint:MPNetworkEndpointEngage andBody:body];
     XCTAssertEqualObjects(request.URL, [NSURL URLWithString:@"http://localhost:31337/engage/"]);
     XCTAssert([request.HTTPMethod isEqualToString:@"POST"]);
     XCTAssertEqualObjects(request.HTTPBody, [body dataUsingEncoding:NSUTF8StringEncoding]);
@@ -64,10 +60,9 @@
                                                      andToken:@"deadc0de"];
     XCTAssertEqual(items.count, (unsigned long)5, @"returned the wrong number of query items.");
     
-    NSURLRequest *request = [self.network requestForEndpoint:@"/track/"
-                                                byHTTPMethod:@"POST"
-                                              withQueryItems:items];
-    XCTAssertEqualObjects(request.URL.absoluteString, @"http://localhost:31337/track/?version=1&lib=iphone&token=deadc0de&distinct_id=1234&properties=%7B%22bool%22:true,%22test%22:%224%22%7D", @"incorrect URL for the query items.");
+    NSURLRequest *request = [self.network buildGetRequestForEndpoint:MPNetworkEndpointDecide
+                                                      withQueryItems:items];
+    XCTAssertEqualObjects(request.URL.absoluteString, @"http://localhost:31337/decide?version=1&lib=iphone&token=deadc0de&distinct_id=1234&properties=%7B%22bool%22:true,%22test%22:%224%22%7D", @"incorrect URL for the query items.");
 }
 
 #if TARGET_OS_IOS

--- a/Mixpanel/MPNetwork.h
+++ b/Mixpanel/MPNetwork.h
@@ -20,4 +20,12 @@
 
 - (void)updateNetworkActivityIndicator:(BOOL)enabled;
 
+- (NSURLRequest *)requestForEndpoint:(NSString *)endpoint
+                        byHTTPMethod:(NSString *)method
+                      withQueryItems:(NSArray <NSURLQueryItem *> *)queryItems;
+
+- (NSURLRequest *)requestForEndpoint:(NSString *)endpoint
+                        byHTTPMethod:(NSString *)method
+                             andBody:(NSString *)body;
+
 @end

--- a/Mixpanel/MPNetwork.h
+++ b/Mixpanel/MPNetwork.h
@@ -8,6 +8,12 @@
 
 #import <Foundation/Foundation.h>
 
+typedef NS_ENUM(NSUInteger, MPNetworkEndpoint) {
+    MPNetworkEndpointTrack,
+    MPNetworkEndpointEngage,
+    MPNetworkEndpointDecide
+};
+
 @interface MPNetwork : NSObject
 
 @property (nonatomic) BOOL shouldManageNetworkActivityIndicator;
@@ -20,12 +26,10 @@
 
 - (void)updateNetworkActivityIndicator:(BOOL)enabled;
 
-- (NSURLRequest *)requestForEndpoint:(NSString *)endpoint
-                        byHTTPMethod:(NSString *)method
-                      withQueryItems:(NSArray <NSURLQueryItem *> *)queryItems;
+- (NSURLRequest *)buildGetRequestForEndpoint:(MPNetworkEndpoint)endpoint
+                              withQueryItems:(NSArray <NSURLQueryItem *> *)queryItems;
 
-- (NSURLRequest *)requestForEndpoint:(NSString *)endpoint
-                        byHTTPMethod:(NSString *)method
-                             andBody:(NSString *)body;
+- (NSURLRequest *)buildPostRequestForEndpoint:(MPNetworkEndpoint)endpoint
+                                      andBody:(NSString *)body;
 
 @end

--- a/Mixpanel/MPNetwork.m
+++ b/Mixpanel/MPNetwork.m
@@ -48,8 +48,9 @@ static const NSUInteger kBatchSize = 50;
         NSString *requestData = [MPNetwork encodeArrayForAPI:batch];
         NSString *postBody = [NSString stringWithFormat:@"ip=%d&data=%@", self.useIPAddressForGeoLocation, requestData];
         MixpanelDebug(@"%@ flushing %lu of %lu to %@: %@", self, (unsigned long)batch.count, (unsigned long)queue.count, endpoint, queue);
-        NSURLRequest *request = [self requestForEndpoint:endpoint withBody:postBody];
-        
+        NSURLRequest *request = [self requestForEndpoint:endpoint
+                                            byHTTPMethod:@"POST"
+                                                 andBody:postBody];
         [self updateNetworkActivityIndicator:YES];
         
         __block BOOL didFail = NO;
@@ -115,16 +116,62 @@ static const NSUInteger kBatchSize = 50;
 }
 
 #pragma mark - Helpers
-- (NSURLRequest *)requestForEndpoint:(NSString *)endpoint withBody:(NSString *)body {
-    NSURL *URL = [self.serverURL URLByAppendingPathComponent:endpoint];
-    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:URL];
++ (NSArray<NSURLQueryItem *> *)buildDecideQueryForProperties:(NSDictionary *)properties
+                                              withDistinctID:(NSString *)distinctID
+                                                    andToken:(NSString *)token {
+    NSURLQueryItem *itemVersion = [NSURLQueryItem queryItemWithName:@"version" value:@"1"];
+    NSURLQueryItem *itemLib = [NSURLQueryItem queryItemWithName:@"lib" value:@"iphone"];
+    NSURLQueryItem *itemToken = [NSURLQueryItem queryItemWithName:@"token" value:token];
+    NSURLQueryItem *itemDistinctID = [NSURLQueryItem queryItemWithName:@"distinct_id" value:distinctID];
+    
+    // Convert properties dictionary to a string
+    NSData *propertiesData = [NSJSONSerialization dataWithJSONObject:properties
+                                                             options:0
+                                                               error:NULL];
+    NSString *propertiesString = [[NSString alloc] initWithData:propertiesData
+                                                       encoding:NSUTF8StringEncoding];
+    NSURLQueryItem *itemProperties = [NSURLQueryItem queryItemWithName:@"properties" value:propertiesString];
+    
+    return @[ itemVersion, itemLib, itemToken, itemDistinctID, itemProperties ];
+}
+
+- (NSURLRequest *)requestForEndpoint:(NSString *)endpoint
+                        byHTTPMethod:(NSString *)method
+                      withQueryItems:(NSArray <NSURLQueryItem *> *)queryItems {
+    return [self requestForEndpoint:endpoint
+                       byHTTPMethod:method
+                     withQueryItems:queryItems
+                            andBody:nil];
+}
+
+- (NSURLRequest *)requestForEndpoint:(NSString *)endpoint
+                        byHTTPMethod:(NSString *)method
+                             andBody:(NSString *)body {
+    return [self requestForEndpoint:endpoint
+                       byHTTPMethod:method
+                     withQueryItems:nil
+                            andBody:body];
+}
+
+- (NSURLRequest *)requestForEndpoint:(NSString *)endpoint
+                        byHTTPMethod:(NSString *)method
+                      withQueryItems:(NSArray <NSURLQueryItem *> *)queryItems
+                             andBody:(NSString *)body {
+    // Build URL from path and query items
+    NSURLComponents *components = [NSURLComponents componentsWithURL:self.serverURL
+                                             resolvingAgainstBaseURL:YES];
+    components.path = endpoint;
+    components.queryItems = queryItems;
+
+    // Build request from URL
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:components.URL];
     [request setValue:@"gzip" forHTTPHeaderField:@"Accept-Encoding"];
-    [request setHTTPMethod:@"POST"];
+    [request setHTTPMethod:method];
     [request setHTTPBody:[body dataUsingEncoding:NSUTF8StringEncoding]];
     
     MixpanelDebug(@"%@ http request: %@?%@", self, URL, body);
     
-    return request;
+    return [request copy];
 }
 
 + (NSString *)encodeArrayForAPI:(NSArray *)array {

--- a/Mixpanel/MPNetworkPrivate.h
+++ b/Mixpanel/MPNetworkPrivate.h
@@ -15,7 +15,24 @@
 @property (nonatomic) NSTimeInterval requestsDisabledUntilTime;
 @property (nonatomic) NSUInteger consecutiveFailures;
 
-- (NSURLRequest *)requestForEndpoint:(NSString *)endpoint withBody:(NSString *)body;
+- (BOOL)handleNetworkResponse:(NSHTTPURLResponse *)response withError:(NSError *)error;
+
++ (NSTimeInterval)calculateBackOffTimeFromFailures:(NSUInteger)failureCount;
++ (NSTimeInterval)parseRetryAfterTime:(NSHTTPURLResponse *)response;
++ (BOOL)parseHTTPFailure:(NSHTTPURLResponse *)response withError:(NSError *)error;
+
 + (NSString *)encodeArrayForAPI:(NSArray *)array;
++ (NSData *)encodeArrayAsJSONData:(NSArray *)array;
++ (NSString *)encodeJSONDataAsBase64:(NSData *)data;
+
++ (NSArray<NSURLQueryItem *> *)buildDecideQueryForProperties:(NSDictionary *)properties
+                                              withDistinctID:(NSString *)distinctID
+                                                    andToken:(NSString *)token;
+
+- (NSURLRequest *)requestForEndpoint:(NSString *)endpoint
+                        byHTTPMethod:(NSString *)method
+                      withQueryItems:(NSArray <NSURLQueryItem *> *)queryItems
+                             andBody:(NSString *)body;
+
 
 @end

--- a/Mixpanel/MPNotification.m
+++ b/Mixpanel/MPNotification.m
@@ -77,12 +77,6 @@ NSString *const MPNotificationTypeTakeover = @"takeover";
             MixpanelError(@"invalid notif image URL: %@", imageURLString);
             return nil;
         }
-        NSString *escapedURLString = [imageURLString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
-        imageURL = [NSURL URLWithString:escapedURLString];
-        if (imageURL == nil) {
-            MixpanelError(@"invalid notif image URL: %@", escapedURLString);
-            return nil;
-        }
 
         NSString *imagePath = imageURL.path;
         if ([type isEqualToString:MPNotificationTypeTakeover]) {
@@ -95,12 +89,12 @@ NSString *const MPNotificationTypeTakeover = @"takeover";
         imageURLComponents.scheme = imageURL.scheme;
         imageURLComponents.host = imageURL.host;
         imageURLComponents.path = imagePath;
-        imageURL = imageURLComponents.URL;
-
-        if (imageURL == nil) {
+        
+        if (imageURLComponents.URL == nil) {
             MixpanelError(@"invalid notif image URL: %@", imageURLString);
             return nil;
         }
+        imageURL = imageURLComponents.URL;
     }
 
     return [[MPNotification alloc] initWithID:ID.unsignedIntegerValue

--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -975,9 +975,7 @@ static void MixpanelReachabilityCallback(SCNetworkReachabilityRef target, SCNetw
         dispatch_group_enter(bgGroup);
         NSString *requestData = [MPNetwork encodeArrayForAPI:@[@{@"event": @"Integration", @"properties": @{@"token": @"85053bf24bba75239b16a601d9387e17", @"mp_lib": @"iphone", @"distinct_id": self.apiToken}}]];
         NSString *postBody = [NSString stringWithFormat:@"ip=%d&data=%@", self.useIPAddressForGeoLocation, requestData];
-        NSURLRequest *request = [self.network requestForEndpoint:@"/track/"
-                                                    byHTTPMethod:@"POST"
-                                                         andBody:postBody];
+        NSURLRequest *request = [self.network buildPostRequestForEndpoint:MPNetworkEndpointTrack andBody:postBody];
         NSURLSession *session = [NSURLSession sharedSession];
         [[session dataTaskWithRequest:request completionHandler:^(NSData *responseData,
                                                                   NSURLResponse *urlResponse,
@@ -1091,9 +1089,8 @@ static void MixpanelReachabilityCallback(SCNetworkReachabilityRef target, SCNetw
             
             
             // Build a network request from the URL
-            NSURLRequest *request = [self.network requestForEndpoint:@"/decide"
-                                                        byHTTPMethod:@"GET"
-                                                      withQueryItems:queryItems];
+            NSURLRequest *request = [self.network buildGetRequestForEndpoint:MPNetworkEndpointDecide
+                                                              withQueryItems:queryItems];
             
             // Send the network request
             NSError *error = nil;

--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -154,14 +154,7 @@ static Mixpanel *sharedInstance;
 }
 #endif
 
-#pragma mark - Encoding/decoding utilities
-static __unused NSString *MPURLEncode(NSString *s)
-{
-    return [s stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
-}
-
 #pragma mark - Tracking
-
 + (void)assertPropertyTypes:(NSDictionary *)properties
 {
     for (id __unused k in properties) {
@@ -982,7 +975,9 @@ static void MixpanelReachabilityCallback(SCNetworkReachabilityRef target, SCNetw
         dispatch_group_enter(bgGroup);
         NSString *requestData = [MPNetwork encodeArrayForAPI:@[@{@"event": @"Integration", @"properties": @{@"token": @"85053bf24bba75239b16a601d9387e17", @"mp_lib": @"iphone", @"distinct_id": self.apiToken}}]];
         NSString *postBody = [NSString stringWithFormat:@"ip=%d&data=%@", self.useIPAddressForGeoLocation, requestData];
-        NSURLRequest *request = [self.network requestForEndpoint:@"/track/" withBody:postBody];
+        NSURLRequest *request = [self.network requestForEndpoint:@"/track/"
+                                                    byHTTPMethod:@"POST"
+                                                         andBody:postBody];
         NSURLSession *session = [NSURLSession sharedSession];
         [[session dataTaskWithRequest:request completionHandler:^(NSData *responseData,
                                                                   NSURLResponse *urlResponse,
@@ -1088,16 +1083,19 @@ static void MixpanelReachabilityCallback(SCNetworkReachabilityRef target, SCNetw
 
         if (!useCache || !self.decideResponseCached) {
             MixpanelDebug(@"%@ decide cache not found, starting network request", self);
-            NSString *distinctId = self.people.distinctId ?: self.distinctId;
-            NSData *peoplePropertiesJSON = [NSJSONSerialization dataWithJSONObject:self.people.automaticPeopleProperties options:(NSJSONWritingOptions)0 error:nil];
-            NSString *params = [NSString stringWithFormat:@"version=1&lib=iphone&token=%@&properties=%@%@",
-                                self.apiToken,
-                                MPURLEncode([[NSString alloc] initWithData:peoplePropertiesJSON encoding:NSUTF8StringEncoding]),
-                                (distinctId ? [NSString stringWithFormat:@"&distinct_id=%@", MPURLEncode(distinctId)] : @"")
-                                ];
-            NSURL *URL = [NSURL URLWithString:[NSString stringWithFormat:@"%@/decide?%@", self.decideURL, params]];
-            NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:URL];
-            [request setValue:@"gzip" forHTTPHeaderField:@"Accept-Encoding"];
+            
+            // Build a proper URL from our parameters
+            NSArray *queryItems = [MPNetwork buildDecideQueryForProperties:self.people.automaticPeopleProperties
+                                                                              withDistinctID:self.people.distinctId ?: self.distinctId
+                                                                                    andToken:self.apiToken];
+            
+            
+            // Build a network request from the URL
+            NSURLRequest *request = [self.network requestForEndpoint:@"/decide"
+                                                        byHTTPMethod:@"GET"
+                                                      withQueryItems:queryItems];
+            
+            // Send the network request
             NSError *error = nil;
             NSURLResponse *urlResponse = nil;
             NSData *data = [NSURLConnection sendSynchronousRequest:request returningResponse:&urlResponse error:&error];
@@ -1108,6 +1106,8 @@ static void MixpanelReachabilityCallback(SCNetworkReachabilityRef target, SCNetw
                 }
                 return;
             }
+            
+            // Handle network response
             NSDictionary *object = [NSJSONSerialization JSONObjectWithData:data options:(NSJSONReadingOptions)0 error:&error];
             if (error) {
                 MixpanelError(@"%@ decide check json error: %@, data: %@", self, error, [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]);


### PR DESCRIPTION
Remove nonsensical URL encoding from MPNotification.

Remove MPNetworkTests.h and move to MPNetworkPrivate.h, fix tests since there was a small refactor, add test that checks full URL is built correctly for decide changes.