### PR TITLE
Add remove people operator + Ability to remove single push device token

### DIFF
--- a/Mixpanel/MixpanelPeople.h
+++ b/Mixpanel/MixpanelPeople.h
@@ -95,7 +95,7 @@ NS_ASSUME_NONNULL_BEGIN
  This will remove the provided push token saved to this people profile. This is useful
  in conjunction with a call to `reset`, or when a user is logging out.
  */
-- (void)removeSinglePushDeviceToken:(NSString *)deviceToken;
+- (void)removeSinglePushDeviceToken:(NSData *)deviceToken;
 
 /*!
  @method

--- a/Mixpanel/MixpanelPeople.h
+++ b/Mixpanel/MixpanelPeople.h
@@ -95,7 +95,7 @@ NS_ASSUME_NONNULL_BEGIN
  This will remove the provided push token saved to this people profile. This is useful
  in conjunction with a call to `reset`, or when a user is logging out.
  */
-- (void)removeSinglePushDeviceToken:(NSData *)properties;
+- (void)removeSinglePushDeviceToken:(NSString *)deviceToken;
 
 /*!
  @method

--- a/Mixpanel/MixpanelPeople.h
+++ b/Mixpanel/MixpanelPeople.h
@@ -89,6 +89,18 @@ NS_ASSUME_NONNULL_BEGIN
  @method
  
  @abstract
+ Unregister a specific device token from the ability to receive push notifications.
+ 
+ @discussion
+ This will remove the provided push token saved to this people profile. This is useful
+ in conjunction with a call to `reset`, or when a user is logging out.
+ */
+- (void)removeSinglePushDeviceToken:(NSData *)properties;
+
+/*!
+ @method
+ 
+ @abstract
  Set properties on the current user in Mixpanel People.
  
  @discussion
@@ -219,6 +231,22 @@ NS_ASSUME_NONNULL_BEGIN
  @param properties      mapping of list property names to lists to union
  */
 - (void)union:(NSDictionary *)properties;
+
+/*!
+ @method
+ 
+ @abstract
+ Remove list properties.
+ 
+ @discussion
+ Property keys must be <code>NSString</code> objects and values must be
+ <code>NSString</code>, <code>NSNumber</code>, <code>NSNull</code>,
+ <code>NSArray</code>, <code>NSDictionary</code>, <code>NSDate</code> or
+ <code>NSURL</code> objects.
+ 
+ @param properties      mapping of list property names to values to remove
+ */
+- (void)remove:(NSDictionary *)properties;
 
 /*!
  @method

--- a/Mixpanel/MixpanelPeople.m
+++ b/Mixpanel/MixpanelPeople.m
@@ -142,8 +142,7 @@
     for (NSUInteger i = 0; i < deviceToken.length; i++) {
         [hex appendString:[NSString stringWithFormat:@"%02lx", (unsigned long)buffer[i]]];
     }
-    NSArray *tokens = @[[NSString stringWithString:hex]];
-    NSDictionary *properties = @{@"$ios_devices": tokens};
+    NSDictionary *properties = @{@"$ios_devices": [NSString stringWithString:hex]};
     [self addPeopleRecordToQueueWithAction:@"$remove" andProperties:properties];
 }
 

--- a/Mixpanel/MixpanelPeople.m
+++ b/Mixpanel/MixpanelPeople.m
@@ -109,7 +109,7 @@
     }
 }
 
-- (void)pushDeviceTokenToString:(NSData *)deviceToken
++ (void)pushDeviceTokenToString:(NSData *)deviceToken
 {
     const unsigned char *buffer = (const unsigned char *)deviceToken.bytes;
     if (!buffer) {
@@ -119,7 +119,7 @@
     for (NSUInteger i = 0; i < deviceToken.length; i++) {
         [hex appendString:[NSString stringWithFormat:@"%02lx", (unsigned long)buffer[i]]];
     }
-    return [NSString stringWithString:hex];
+    return [hex copy];
 }
 
 #pragma mark - Public API

--- a/Mixpanel/MixpanelPeople.m
+++ b/Mixpanel/MixpanelPeople.m
@@ -132,8 +132,12 @@
     [self addPeopleRecordToQueueWithAction:@"$unset" andProperties:properties];
 }
 
-- (void)removeSinglePushDeviceToken:(NSDictionary *)properties
+- (void)removeSinglePushDeviceToken:(NSString *)deviceToken
 {
+    if(deviceToken == nil) {
+        return;
+    }
+    NSDictionary *properties = @{ @"$ios_devices": deviceToken };
     [self addPeopleRecordToQueueWithAction:@"$remove" andProperties:properties];
 }
 

--- a/Mixpanel/MixpanelPeople.m
+++ b/Mixpanel/MixpanelPeople.m
@@ -132,12 +132,18 @@
     [self addPeopleRecordToQueueWithAction:@"$unset" andProperties:properties];
 }
 
-- (void)removeSinglePushDeviceToken:(NSString *)deviceToken
+- (void)removeSinglePushDeviceToken:(NSData *)deviceToken
 {
-    if(deviceToken == nil) {
+    const unsigned char *buffer = (const unsigned char *)deviceToken.bytes;
+    if (!buffer) {
         return;
     }
-    NSDictionary *properties = @{ @"$ios_devices": deviceToken };
+    NSMutableString *hex = [NSMutableString stringWithCapacity:(deviceToken.length * 2)];
+    for (NSUInteger i = 0; i < deviceToken.length; i++) {
+        [hex appendString:[NSString stringWithFormat:@"%02lx", (unsigned long)buffer[i]]];
+    }
+    NSArray *tokens = @[[NSString stringWithString:hex]];
+    NSDictionary *properties = @{@"$ios_devices": tokens};
     [self addPeopleRecordToQueueWithAction:@"$remove" andProperties:properties];
 }
 

--- a/Mixpanel/MixpanelPeople.m
+++ b/Mixpanel/MixpanelPeople.m
@@ -109,9 +109,7 @@
     }
 }
 
-#pragma mark - Public API
-
-- (void)addPushDeviceToken:(NSData *)deviceToken
+- (void)pushDeviceTokenToString:(NSData *)deviceToken
 {
     const unsigned char *buffer = (const unsigned char *)deviceToken.bytes;
     if (!buffer) {
@@ -121,8 +119,14 @@
     for (NSUInteger i = 0; i < deviceToken.length; i++) {
         [hex appendString:[NSString stringWithFormat:@"%02lx", (unsigned long)buffer[i]]];
     }
-    NSArray *tokens = @[[NSString stringWithString:hex]];
-    NSDictionary *properties = @{@"$ios_devices": tokens};
+    return [NSString stringWithString:hex];
+}
+
+#pragma mark - Public API
+
+- (void)addPushDeviceToken:(NSData *)deviceToken
+{
+    NSDictionary *properties = @{@"$ios_devices": @[pushDeviceTokenToString(deviceToken)]};
     [self addPeopleRecordToQueueWithAction:@"$union" andProperties:properties];
 }
 
@@ -134,15 +138,7 @@
 
 - (void)removeSinglePushDeviceToken:(NSData *)deviceToken
 {
-    const unsigned char *buffer = (const unsigned char *)deviceToken.bytes;
-    if (!buffer) {
-        return;
-    }
-    NSMutableString *hex = [NSMutableString stringWithCapacity:(deviceToken.length * 2)];
-    for (NSUInteger i = 0; i < deviceToken.length; i++) {
-        [hex appendString:[NSString stringWithFormat:@"%02lx", (unsigned long)buffer[i]]];
-    }
-    NSDictionary *properties = @{@"$ios_devices": [NSString stringWithString:hex]};
+    NSDictionary *properties = @{@"$ios_devices": pushDeviceTokenToString(deviceToken)};
     [self addPeopleRecordToQueueWithAction:@"$remove" andProperties:properties];
 }
 

--- a/Mixpanel/MixpanelPeople.m
+++ b/Mixpanel/MixpanelPeople.m
@@ -132,6 +132,11 @@
     [self addPeopleRecordToQueueWithAction:@"$unset" andProperties:properties];
 }
 
+- (void)removeSinglePushDeviceToken:(NSDictionary *)properties
+{
+    [self addPeopleRecordToQueueWithAction:@"$remove" andProperties:properties];
+}
+
 - (void)set:(NSDictionary *)properties
 {
     NSAssert(properties != nil, @"properties must not be nil");
@@ -203,6 +208,13 @@
                  @"%@ union property values should be NSArray. found: %@", self, v);
     }
     [self addPeopleRecordToQueueWithAction:@"$union" andProperties:properties];
+}
+
+- (void)remove:(NSDictionary *)properties
+{
+    NSAssert(properties != nil, @"properties must not be nil");
+    [Mixpanel assertPropertyTypes:properties];
+    [self addPeopleRecordToQueueWithAction:@"$remove" andProperties:properties];
 }
 
 - (void)merge:(NSDictionary *)properties


### PR DESCRIPTION
Add support for the ```$remove``` operator which is detailed [here](https://mixpanel.com/help/reference/http#people-analytics-updates). Using this ```$remove``` operator, an additional method ```removeSinglePushDeviceToken``` has been added to allow for a single push notification device token to be removed from a user's profile.