### PR TITLE
Remove unused local variable

### DIFF
--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -847,12 +847,11 @@ static Mixpanel *sharedInstance;
 
 #if !defined(MIXPANEL_TVOS_EXTENSION)
     // wifi reachability
-    BOOL reachabilityOk = NO;
     if ((_reachability = SCNetworkReachabilityCreateWithName(NULL, "api.mixpanel.com")) != NULL) {
         SCNetworkReachabilityContext context = {0, (__bridge void*)self, NULL, NULL, NULL};
         if (SCNetworkReachabilitySetCallback(_reachability, MixpanelReachabilityCallback, &context)) {
             if (SCNetworkReachabilitySetDispatchQueue(_reachability, self.serialQueue)) {
-                reachabilityOk = YES;
+                // success, nothing to do
             } else {
                 // cleanup callback if setting dispatch queue failed
                 SCNetworkReachabilitySetCallback(_reachability, NULL, NULL);


### PR DESCRIPTION
This was generating a Clang static analyser warning that `reachabilityOk` was being written but never read. This appears to be a new warning upon updating from 3.0.0 to 3.0.2.