### PR TITLE
Fix Code Sign iOS

### DIFF
--- a/Mixpanel.xcodeproj/project.pbxproj
+++ b/Mixpanel.xcodeproj/project.pbxproj
@@ -1443,7 +1443,6 @@
 		7C170C411A4A02F500D9E0F2 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREFIX_HEADER = "";
@@ -1465,7 +1464,6 @@
 		7C170C421A4A02F500D9E0F2 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				GCC_PREFIX_HEADER = "";
 				GCC_TREAT_WARNINGS_AS_ERRORS = NO;


### PR DESCRIPTION
I have a code sign problem on the v3.0.3, I can't use Mixpanel v3.0.3 as a carthage dependency because of that. Here is the fix.
![screen shot 2016-09-09 at 14 03 34](https://cloud.githubusercontent.com/assets/1238254/18386785/66ce828c-7699-11e6-8e40-47da3e121c6a.png)
