### PR TITLE
removePushDeviceToken fix

### DIFF
--- a/Mixpanel/MixpanelPeople.m
+++ b/Mixpanel/MixpanelPeople.m
@@ -138,7 +138,7 @@
 
 - (void)removePushDeviceToken:(NSData *)deviceToken
 {
-    NSDictionary *properties = @{@"$ios_devices": @[[MixpanelPeople pushDeviceTokenToString:deviceToken]]};
+    NSDictionary *properties = @{@"$ios_devices": [MixpanelPeople pushDeviceTokenToString:deviceToken]};
     [self addPeopleRecordToQueueWithAction:@"$remove" andProperties:properties];
 }
 


### PR DESCRIPTION
Original removePushDeviceToken function would make device token value a list, which would result in the $remove operation not working:

$remove":{"$ios_devices":["1719128325f7036b765fcd5087bbac542b6ae0becdd1003674faaad6f1918721"]}

Through making it a string we can ensure that the $remove operation will work:

$remove":{"$ios_devices":"1719128325f7036b765fcd5087bbac542b6ae0becdd1003674faaad6f1918721"}