### PR TITLE
Updated defaultDistinctId for iOS 10 changes to limiting ad tracking.

### DIFF
--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -197,7 +197,7 @@ static Mixpanel *sharedInstance;
 {
     NSString *distinctId = [self IFA];
 
-    if (!distinctId && NSClassFromString(@"UIDevice")) {
+    if ((!distinctId && NSClassFromString(@"UIDevice")) || [distinctId isEqualToString:@"00000000-0000-0000-0000-000000000000"]) {
         distinctId = [[UIDevice currentDevice].identifierForVendor UUIDString];
     }
     if (!distinctId) {


### PR DESCRIPTION
Starting with iOS 10 a user having "Limit Ad Tracking" enabled results in the request for the users IFA to respond with "00000000-0000-0000-0000-000000000000".  Since the current IFA check in the defaultDistinctId checking for nil multiple users could be provided with the same DistinctId and therefore combining their data into one mixpanel user.  

In order to resolve this I simply added a check to the check if there is a need to fall back to the users IFV instead of their IFA for the 0'd out IFA.

See: https://developer.apple.com/reference/adsupport/asidentifiermanager