### PR TITLE
Fixes an issue that prevents having custom server urls

### DIFF
--- a/Mixpanel/MPNetwork.m
+++ b/Mixpanel/MPNetwork.m
@@ -169,7 +169,7 @@ static const NSUInteger kBatchSize = 50;
     // Build URL from path and query items
     NSURLComponents *components = [NSURLComponents componentsWithURL:self.serverURL
                                              resolvingAgainstBaseURL:YES];
-    components.path = endpoint;
+    components.path = [components.path stringByAppendingPathComponent:endpoint];
     components.queryItems = queryItems;
 
     // Build request from URL


### PR DESCRIPTION
In the new version having a custom server url path like
https://domain.com/v1/track/mixpanel wouldn't work because the url components' path is overwritten with a hardcoded path rather than the hardcoded path is appended only.