### PR TITLE
some of our endpoints are specified with trailing slashes. stringByAp…

### DIFF
--- a/Mixpanel/MPNetwork.m
+++ b/Mixpanel/MPNetwork.m
@@ -169,9 +169,9 @@ static const NSUInteger kBatchSize = 50;
                            withQueryItems:(NSArray <NSURLQueryItem *> *)queryItems
                                   andBody:(NSString *)body {
     // Build URL from path and query items
-    NSURLComponents *components = [NSURLComponents componentsWithURL:self.serverURL
+    NSURL *urlWithEndpoint = [self.serverURL URLByAppendingPathComponent:endpoint];
+    NSURLComponents *components = [NSURLComponents componentsWithURL:urlWithEndpoint
                                              resolvingAgainstBaseURL:YES];
-    components.path = [components.path stringByAppendingPathComponent:endpoint];
     components.queryItems = queryItems;
 
     // Build request from URL


### PR DESCRIPTION
…pendingPathComponent appears to strip out all trailing slashes, and apple's docs claim it's for file paths, not urls. using NSURL to append brings this back in line with previous behavior (which fixes unit tests that were breaking)