### PR TITLE
Renames MPClassDescription method parameter name

### DIFF
--- a/Mixpanel/MPClassDescription.h
+++ b/Mixpanel/MPClassDescription.h
@@ -12,7 +12,7 @@
 
 - (instancetype)initWithSuperclassDescription:(MPClassDescription *)superclassDescription dictionary:(NSDictionary *)dictionary;
 
-- (BOOL)isDescriptionForKindOfClass:(Class)class;
+- (BOOL)isDescriptionForKindOfClass:(Class)aClass;
 
 @end
 

--- a/Mixpanel/MPClassDescription.m
+++ b/Mixpanel/MPClassDescription.m
@@ -64,9 +64,9 @@
     return allPropertyDescriptions.allValues;
 }
 
-- (BOOL)isDescriptionForKindOfClass:(Class)class
+- (BOOL)isDescriptionForKindOfClass:(Class)aClass
 {
-    return [self.name isEqualToString:NSStringFromClass(class)] && [self.superclassDescription isDescriptionForKindOfClass:[class superclass]];
+    return [self.name isEqualToString:NSStringFromClass(aClass)] && [self.superclassDescription isDescriptionForKindOfClass:[aClass superclass]];
 }
 
 - (NSString *)debugDescription


### PR DESCRIPTION
While compiling with Swift, modules enabled, and the `-fcxx-modules` flag, build failed in line 15:

`- (BOOL)isDescriptionForKindOfClass:(Class)class;`

Changing the parameter name from `class` to `aClass`, as seen in [`NSObject`s declarations](https://developer.apple.com/reference/objectivec/1418956-nsobject/1418511-iskindofclass) fixed it.
