### PR TITLE
Recursively check types of properties

### DIFF
--- a/Mixpanel/MixpanelPeople.m
+++ b/Mixpanel/MixpanelPeople.m
@@ -158,7 +158,7 @@
 - (void)set:(NSDictionary *)properties
 {
     NSAssert(properties != nil, @"properties must not be nil");
-    [Mixpanel assertPropertyTypes:properties];
+    [Mixpanel assertPropertyTypesInDictionary:properties];
     [self addPeopleRecordToQueueWithAction:@"$set" andProperties:properties];
 }
 
@@ -175,7 +175,7 @@
 - (void)setOnce:(NSDictionary *)properties
 {
     NSAssert(properties != nil, @"properties must not be nil");
-    [Mixpanel assertPropertyTypes:properties];
+    [Mixpanel assertPropertyTypesInDictionary:properties];
     [self addPeopleRecordToQueueWithAction:@"$set_once" andProperties:properties];
 }
 
@@ -214,7 +214,7 @@
 - (void)append:(NSDictionary *)properties
 {
     NSAssert(properties != nil, @"properties must not be nil");
-    [Mixpanel assertPropertyTypes:properties];
+    [Mixpanel assertPropertyTypesInDictionary:properties];
     [self addPeopleRecordToQueueWithAction:@"$append" andProperties:properties];
 }
 
@@ -231,7 +231,7 @@
 - (void)remove:(NSDictionary *)properties
 {
     NSAssert(properties != nil, @"properties must not be nil");
-    [Mixpanel assertPropertyTypes:properties];
+    [Mixpanel assertPropertyTypesInDictionary:properties];
     [self addPeopleRecordToQueueWithAction:@"$remove" andProperties:properties];
 }
 

--- a/Mixpanel/MixpanelPrivate.h
+++ b/Mixpanel/MixpanelPrivate.h
@@ -100,7 +100,7 @@
 
 @property (atomic, copy) NSString *switchboardURL;
 
-+ (void)assertPropertyTypes:(NSDictionary *)properties;
++ (void)assertPropertyTypesInDictionary:(NSDictionary *)properties;
 
 - (NSString *)deviceModel;
 - (NSString *)IFA;


### PR DESCRIPTION
I've faced the problem when swift optionals were passed inside containers (arrays or dictionaries) to Mixpanel and the asserts did not catch it.

This resulted in cycle-crash on `[NSKeyedUnarchiver unarchiveObjectWithFile:filePath]` in `+ (id)unarchiveFromFile:(NSString *)filePath asClass:(Class)class` method with the stacktrace below (`try-catch` did not save the situation):

> Crashed: com.apple.main-thread
0  libswiftCore.dylib             0x28e9176 +[_SwiftValue allocWithZone:] + 27
1  Foundation                     0x1f5ab96f _decodeObjectBinary + 2650
2  Foundation                     0x1f5b1d3d -[NSKeyedUnarchiver _decodeArrayOfObjectsForKey:] + 1642
3  Foundation                     0x1f54cca7 -[NSArray(NSArray) initWithCoder:] + 322
4  Foundation                     0x1f5ab9a5 _decodeObjectBinary + 2704
5  Foundation                     0x1f5b1d3d -[NSKeyedUnarchiver _decodeArrayOfObjectsForKey:] + 1642
6  Foundation                     0x1f58c27f -[NSDictionary(NSDictionary) initWithCoder:] + 322
7  Foundation                     0x1f5ab9a5 _decodeObjectBinary + 2704
8  Foundation                     0x1f5b1d3d -[NSKeyedUnarchiver _decodeArrayOfObjectsForKey:] + 1642
9  Foundation                     0x1f58c27f -[NSDictionary(NSDictionary) initWithCoder:] + 322
10 Foundation                     0x1f5ab9a5 _decodeObjectBinary + 2704
11 Foundation                     0x1f5b1d3d -[NSKeyedUnarchiver _decodeArrayOfObjectsForKey:] + 1642
12 Foundation                     0x1f54cca7 -[NSArray(NSArray) initWithCoder:] + 322
13 Foundation                     0x1f5ab9a5 _decodeObjectBinary + 2704
14 Foundation                     0x1f5aae6d _decodeObject + 256
15 Foundation                     0x1f610301 +[NSKeyedUnarchiver unarchiveObjectWithFile:] + 232
16 myappname                      0x65611f +[Mixpanel unarchiveFromFile:asClass:] (Mixpanel.m:659)
17 myappname                      0x656069 +[Mixpanel unarchiveOrDefaultFromFile:asClass:] (Mixpanel.m:652)
18 myappname                      0x6562f7 -[Mixpanel unarchiveEvents] (Mixpanel.m:682)
19 myappname                      0x656007 -[Mixpanel unarchive] (Mixpanel.m:644)
20 myappname                      0x6530d9 -[Mixpanel initWithToken:launchOptions:andFlushInterval:] (Mixpanel.m:111)

With the following changes asserts are firing in case of unsupported types inside arrays and dictionaries.