### PR TITLE
Adding identify: safety check

### DIFF
--- a/Mixpanel/Mixpanel.h
+++ b/Mixpanel/Mixpanel.h
@@ -72,14 +72,27 @@ NS_ASSUME_NONNULL_BEGIN
  The distinct ID of the current user.
 
  @discussion
- A distinct ID is a string that uniquely identifies one of your users.
- Typically, this is the user ID from your database. By default, we'll use
- the device's advertisingIdentifier UUIDString, if that is not available
+ A distinct ID is a string that uniquely identifies one of your users. By default, 
+ we'll use the device's advertisingIdentifier UUIDString, if that is not available
  we'll use the device's identifierForVendor UUIDString, and finally if that
  is not available we will generate a new random UUIDString. To change the
  current distinct ID, use the <code>identify:</code> method.
  */
 @property (atomic, readonly, copy) NSString *distinctId;
+
+/*!
+ @property
+ 
+ @abstract
+ The alias of the current user.
+ 
+ @discussion
+ An alias is another string that uniquely identifies one of your users. Typically, 
+ this is the user ID from your database. By using an alias you can link pre- and
+ post-sign up activity as well as cross-platform activity under one distinct ID.
+ To set the alias use the <code>createAlias:forDistinctID:</code> method.
+ */
+@property (atomic, readonly, copy) NSString *alias;
 
 /*!
  @property

--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -278,8 +278,13 @@ static NSString *defaultProjectToken;
     }
     
     dispatch_async(self.serialQueue, ^{
-        self.distinctId = distinctId;
-        self.people.distinctId = distinctId;
+        // identify only changes the distinct id if it doesn't match either the existing or the alias;
+        // if it's new, blow away the alias as well.
+        if (distinctId != self.distinctId && distinctId != self.alias) {
+            self.alias = nil;
+            self.distinctId = distinctId;
+            self.people.distinctId = distinctId;
+        }
         if (self.people.unidentifiedQueue.count > 0) {
             for (NSMutableDictionary *r in self.people.unidentifiedQueue) {
                 r[@"$distinct_id"] = distinctId;
@@ -305,8 +310,16 @@ static NSString *defaultProjectToken;
         MPLogError(@"%@ create alias called with empty distinct id: %@", self, distinctID);
         return;
     }
-    [self track:@"$create_alias" properties:@{ @"distinct_id": distinctID, @"alias": alias }];
-    [self flush];
+    if (alias != distinctID) {
+        self.alias = alias;
+        [self track:@"$create_alias" properties:@{ @"distinct_id": distinctID, @"alias": alias }];
+        dispatch_async(self.serialQueue, ^{
+            [self archiveProperties];
+        });
+        [self flush];
+    } else {
+        MPLogWarning(@"alias matches distinctID - skipping api call.");
+    }
 }
 
 - (void)track:(NSString *)event
@@ -486,6 +499,7 @@ static NSString *defaultProjectToken;
         self.distinctId = [self defaultDistinctId];
         self.superProperties = [NSMutableDictionary dictionary];
         self.people.distinctId = nil;
+        self.alias = nil;
         self.people.unidentifiedQueue = [NSMutableArray array];
         self.eventsQueue = [NSMutableArray array];
         self.peopleQueue = [NSMutableArray array];
@@ -647,6 +661,7 @@ static NSString *defaultProjectToken;
     NSString *filePath = [self propertiesFilePath];
     NSMutableDictionary *p = [NSMutableDictionary dictionary];
     [p setValue:self.distinctId forKey:@"distinctId"];
+    [p setValue:self.alias forKey:@"alias"];
     [p setValue:self.superProperties forKey:@"superProperties"];
     [p setValue:self.people.distinctId forKey:@"peopleDistinctId"];
     [p setValue:self.people.unidentifiedQueue forKey:@"peopleUnidentifiedQueue"];

--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -772,6 +772,7 @@ static NSString *defaultProjectToken;
     NSDictionary *properties = (NSDictionary *)[Mixpanel unarchiveFromFile:[self propertiesFilePath] asClass:[NSDictionary class]];
     if (properties) {
         self.distinctId = properties[@"distinctId"] ?: [self defaultDistinctId];
+        self.alias = properties[@"alias"];
         self.superProperties = properties[@"superProperties"] ?: [NSMutableDictionary dictionary];
         self.people.distinctId = properties[@"peopleDistinctId"];
         self.people.unidentifiedQueue = properties[@"peopleUnidentifiedQueue"] ?: [NSMutableArray array];

--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -280,14 +280,14 @@ static NSString *defaultProjectToken;
     dispatch_async(self.serialQueue, ^{
         // identify only changes the distinct id if it doesn't match either the existing or the alias;
         // if it's new, blow away the alias as well.
-        if (distinctId != self.distinctId && distinctId != self.alias) {
+        if (![distinctId isEqualToString:self.distinctId] && ![distinctId isEqualToString:self.alias]) {
             self.alias = nil;
             self.distinctId = distinctId;
             self.people.distinctId = distinctId;
         }
         if (self.people.unidentifiedQueue.count > 0) {
             for (NSMutableDictionary *r in self.people.unidentifiedQueue) {
-                r[@"$distinct_id"] = distinctId;
+                r[@"$distinct_id"] = self.distinctId;
                 [self.peopleQueue addObject:r];
             }
             [self.people.unidentifiedQueue removeAllObjects];
@@ -310,15 +310,15 @@ static NSString *defaultProjectToken;
         MPLogError(@"%@ create alias called with empty distinct id: %@", self, distinctID);
         return;
     }
-    if (alias != distinctID) {
-        self.alias = alias;
+    if (![alias isEqualToString:distinctID]) {
         [self track:@"$create_alias" properties:@{ @"distinct_id": distinctID, @"alias": alias }];
+        [self flush];
         dispatch_async(self.serialQueue, ^{
+            self.alias = alias;
             [self archiveProperties];
         });
-        [self flush];
     } else {
-        MPLogWarning(@"alias matches distinctID - skipping api call.");
+        MPLogWarning(@"alias: %@ matches distinctID: %@ - skipping api call.", alias, distinctID);
     }
 }
 

--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -311,12 +311,12 @@ static NSString *defaultProjectToken;
         return;
     }
     if (![alias isEqualToString:distinctID]) {
-        [self track:@"$create_alias" properties:@{ @"distinct_id": distinctID, @"alias": alias }];
-        [self flush];
         dispatch_async(self.serialQueue, ^{
             self.alias = alias;
             [self archiveProperties];
         });
+        [self track:@"$create_alias" properties:@{ @"distinct_id": distinctID, @"alias": alias }];
+        [self flush];
     } else {
         MPLogWarning(@"alias: %@ matches distinctID: %@ - skipping api call.", alias, distinctID);
     }

--- a/Mixpanel/MixpanelPrivate.h
+++ b/Mixpanel/MixpanelPrivate.h
@@ -76,6 +76,7 @@
 @property (atomic, strong) MixpanelPeople *people;
 @property (atomic, strong) MPNetwork *network;
 @property (atomic, copy) NSString *distinctId;
+@property (atomic, copy) NSString *alias;
 
 @property (nonatomic, copy) NSString *apiToken;
 @property (atomic, strong) NSDictionary *superProperties;


### PR DESCRIPTION
Ported the safety check from our js lib, which only changes the distinct_id when calling identify if the given distinct_id is different from the existing distinct_id and the alias. Required creating an alias property.

For reference: https://github.com/mixpanel/mixpanel-js/blob/master/src/mixpanel-core.js#L1339-L1343