### PR TITLE
potential fix for "Multiple methods named 'initWithType:' found with …

### DIFF
--- a/Mixpanel/MPABTestDesignerChangeRequestMessage.m
+++ b/Mixpanel/MPABTestDesignerChangeRequestMessage.m
@@ -13,7 +13,7 @@ NSString *const MPABTestDesignerChangeRequestMessageType = @"change_request";
 
 + (instancetype)message
 {
-    return [[self alloc] initWithType:MPABTestDesignerChangeRequestMessageType];
+    return [(MPABTestDesignerChangeRequestMessage *)[self alloc] initWithType:MPABTestDesignerChangeRequestMessageType];
 }
 
 - (NSOperation *)responseCommandWithConnection:(MPABTestDesignerConnection *)connection

--- a/Mixpanel/MPABTestDesignerChangeResponseMessage.m
+++ b/Mixpanel/MPABTestDesignerChangeResponseMessage.m
@@ -7,7 +7,7 @@
 
 + (instancetype)message
 {
-    return [[self alloc] initWithType:@"change_response"];
+    return [(MPABTestDesignerChangeResponseMessage *)[self alloc] initWithType:@"change_response"];
 }
 
 - (void)setStatus:(NSString *)status

--- a/Mixpanel/MPABTestDesignerClearRequestMessage.m
+++ b/Mixpanel/MPABTestDesignerClearRequestMessage.m
@@ -17,7 +17,7 @@ NSString *const MPABTestDesignerClearRequestMessageType = @"clear_request";
 
 + (instancetype)message
 {
-    return [[self alloc] initWithType:MPABTestDesignerClearRequestMessageType];
+    return [(MPABTestDesignerClearRequestMessage *)[self alloc] initWithType:MPABTestDesignerClearRequestMessageType];
 }
 
 - (NSOperation *)responseCommandWithConnection:(MPABTestDesignerConnection *)connection

--- a/Mixpanel/MPABTestDesignerClearResponseMessage.m
+++ b/Mixpanel/MPABTestDesignerClearResponseMessage.m
@@ -12,7 +12,7 @@
 
 + (instancetype)message
 {
-    return [[self alloc] initWithType:@"clear_response"];
+    return [(MPABTestDesignerClearResponseMessage *)[self alloc] initWithType:@"clear_response"];
 }
 
 - (void)setStatus:(NSString *)status

--- a/Mixpanel/MPABTestDesignerDeviceInfoRequestMessage.m
+++ b/Mixpanel/MPABTestDesignerDeviceInfoRequestMessage.m
@@ -14,7 +14,7 @@ NSString *const MPABTestDesignerDeviceInfoRequestMessageType = @"device_info_req
 
 + (instancetype)message
 {
-    return [[self alloc] initWithType:MPABTestDesignerDeviceInfoRequestMessageType];
+    return [(MPABTestDesignerDeviceInfoRequestMessage *)[self alloc] initWithType:MPABTestDesignerDeviceInfoRequestMessageType];
 }
 
 - (NSOperation *)responseCommandWithConnection:(MPABTestDesignerConnection *)connection

--- a/Mixpanel/MPABTestDesignerDeviceInfoResponseMessage.m
+++ b/Mixpanel/MPABTestDesignerDeviceInfoResponseMessage.m
@@ -8,7 +8,7 @@
 + (instancetype)message
 {
     // TODO: provide a payload
-    return [[self alloc] initWithType:@"device_info_response"];
+    return [(MPABTestDesignerDeviceInfoResponseMessage *)[self alloc] initWithType:@"device_info_response"];
 }
 
 - (NSString *)systemName

--- a/Mixpanel/MPABTestDesignerDisconnectMessage.m
+++ b/Mixpanel/MPABTestDesignerDisconnectMessage.m
@@ -16,7 +16,7 @@ NSString *const MPABTestDesignerDisconnectMessageType = @"disconnect";
 
 + (instancetype)message
 {
-    return [[self alloc] initWithType:MPABTestDesignerDisconnectMessageType];
+    return [(MPABTestDesignerDisconnectMessage *)[self alloc] initWithType:MPABTestDesignerDisconnectMessageType];
 }
 
 - (NSOperation *)responseCommandWithConnection:(MPABTestDesignerConnection *)connection

--- a/Mixpanel/MPABTestDesignerSnapshotRequestMessage.m
+++ b/Mixpanel/MPABTestDesignerSnapshotRequestMessage.m
@@ -17,7 +17,7 @@ static NSString * const kObjectIdentityProviderKey = @"object_identity_provider"
 
 + (instancetype)message
 {
-    return [[self alloc] initWithType:MPABTestDesignerSnapshotRequestMessageType];
+    return [(MPABTestDesignerSnapshotRequestMessage *)[self alloc] initWithType:MPABTestDesignerSnapshotRequestMessageType];
 }
 
 - (MPObjectSerializerConfig *)configuration

--- a/Mixpanel/MPABTestDesignerSnapshotResponseMessage.m
+++ b/Mixpanel/MPABTestDesignerSnapshotResponseMessage.m
@@ -8,7 +8,7 @@
 
 + (instancetype)message
 {
-    return [[self alloc] initWithType:@"snapshot_response"];
+    return [(MPABTestDesignerSnapshotResponseMessage *)[self alloc] initWithType:@"snapshot_response"];
 }
 
 - (void)setScreenshot:(UIImage *)screenshot

--- a/Mixpanel/MPABTestDesignerTweakRequestMessage.m
+++ b/Mixpanel/MPABTestDesignerTweakRequestMessage.m
@@ -18,7 +18,7 @@ NSString *const MPABTestDesignerTweakRequestMessageType = @"tweak_request";
 
 + (instancetype)message
 {
-    return [[self alloc] initWithType:MPABTestDesignerTweakRequestMessageType];
+    return [(MPABTestDesignerTweakRequestMessage *)[self alloc] initWithType:MPABTestDesignerTweakRequestMessageType];
 }
 
 - (NSOperation *)responseCommandWithConnection:(MPABTestDesignerConnection *)connection

--- a/Mixpanel/MPABTestDesignerTweakResponseMessage.m
+++ b/Mixpanel/MPABTestDesignerTweakResponseMessage.m
@@ -12,7 +12,7 @@
 
 + (instancetype)message
 {
-    return [[self alloc] initWithType:@"tweak_response"];
+    return [(MPABTestDesignerTweakResponseMessage *)[self alloc] initWithType:@"tweak_response"];
 }
 
 - (void)setStatus:(NSString *)status

--- a/Mixpanel/MPAbstractABTestDesignerMessage.m
+++ b/Mixpanel/MPAbstractABTestDesignerMessage.m
@@ -18,7 +18,7 @@
 
 + (instancetype)messageWithType:(NSString *)type payload:(NSDictionary *)payload
 {
-    return [[self alloc] initWithType:type payload:payload];
+    return [(MPAbstractABTestDesignerMessage *)[self alloc] initWithType:type payload:payload];
 }
 
 - (instancetype)initWithType:(NSString *)type

--- a/Mixpanel/MPDesignerEventBindingRequestMesssage.m
+++ b/Mixpanel/MPDesignerEventBindingRequestMesssage.m
@@ -57,7 +57,7 @@ NSString *const MPDesignerEventBindingRequestMessageType = @"event_binding_reque
 
 + (instancetype)message
 {
-    return [[self alloc] initWithType:@"event_binding_request"];
+    return [(MPDesignerEventBindingRequestMessage *)[self alloc] initWithType:@"event_binding_request"];
 }
 
 - (NSOperation *)responseCommandWithConnection:(MPABTestDesignerConnection *)connection

--- a/Mixpanel/MPDesignerEventBindingResponseMesssage.m
+++ b/Mixpanel/MPDesignerEventBindingResponseMesssage.m
@@ -12,7 +12,7 @@
 
 + (instancetype)message
 {
-    return [[self alloc] initWithType:@"event_binding_response"];
+    return [(MPDesignerEventBindingResponseMessage *)[self alloc] initWithType:@"event_binding_response"];
 }
 
 - (void)setStatus:(NSString *)status

--- a/Mixpanel/MPDesignerTrackMessage.m
+++ b/Mixpanel/MPDesignerTrackMessage.m
@@ -16,12 +16,12 @@
 
 + (instancetype)message
 {
-    return [[self alloc] initWithType:@"track_message"];
+    return [(MPDesignerTrackMessage *)[self alloc] initWithType:@"track_message"];
 }
 
 + (instancetype)messageWithPayload:(NSDictionary *)payload
 {
-    return[[self alloc] initWithType:@"track_message" andPayload:payload];
+    return [(MPDesignerTrackMessage *)[self alloc] initWithType:@"track_message" andPayload:payload];
 }
 
 - (instancetype)initWithType:(NSString *)type


### PR DESCRIPTION
…mismatched result, parameter type or attributes". casting should help if the compiler is unable to determine which 'initWithType:' it should be using