### PR TITLE
Separate network queue

### DIFF
--- a/HelloMixpanel/HelloMixpanelTests/ABTestingTests.m
+++ b/HelloMixpanel/HelloMixpanelTests/ABTestingTests.m
@@ -316,7 +316,7 @@
     
     // Test that calling again uses the cache (no extra requests to decide).
     [self.mixpanel checkForDecideResponseWithCompletion:nil];
-    [self waitForSerialQueue];
+    [self waitForMixpanelQueues];
     
     XCTAssertEqual([self.mixpanel.variants count], (uint)2, @"no variants found");
     
@@ -324,7 +324,7 @@
     [self.mixpanel checkForDecideResponseWithCompletion:^(NSArray *surveys, NSArray *notifications, NSSet *variants, NSSet *eventBindings) {
         XCTAssertEqual([variants count], 0u, @"Should not get any *new* variants if the decide response was the same");
     } useCache:NO];
-    [self waitForSerialQueue];
+    [self waitForMixpanelQueues];
     
     [[LSNocilla sharedInstance] clearStubs];
     [self stubDecide:@"test_decide_response_2"];
@@ -334,7 +334,7 @@
         completionCalled = YES;
         XCTAssertEqual([variants count], 1u, @"Should have got 1 new variants from decide (new variant for same experiment)");
     } useCache:NO];
-    [self waitForSerialQueue];
+    [self waitForMixpanelQueues];
     XCTAssert(completionCalled, @"completion block should have been called");
     
     // Reset to default decide response
@@ -351,7 +351,7 @@
 
     [self.mixpanel identify:@"ABC"];
     [self.mixpanel joinExperiments];
-    [self waitForSerialQueue];
+    [self waitForMixpanelQueues];
 
     XCTAssertEqual([self.mixpanel.variants count], 2u, @"Should have 2 variants");
     XCTAssertEqual([[self.mixpanel.variants objectsPassingTest:^BOOL(MPVariant *variant, BOOL *stop) { return variant.ID == 1 && variant.running;}] count], 1u, @"We should be running variant 1");
@@ -366,7 +366,7 @@
     [self.mixpanel joinExperimentsWithCallback:^{
         XCTAssert(lastCall, @"callback should run after variants have been processed");
     }];
-    [self waitForSerialQueue];
+    [self waitForMixpanelQueues];
 
     XCTAssertEqual([self.mixpanel.variants count], 3u, @"Should have 3 variants");
     XCTAssertEqual([[self.mixpanel.variants objectsPassingTest:^BOOL(MPVariant *variant, BOOL *stop) { return variant.ID == 1 && variant.running;}] count], 1u, @"We should be running variant 1");
@@ -386,7 +386,7 @@
             [self.mixpanel markVariantRun:variant];
         }
     }];
-    [self waitForSerialQueue];
+    [self waitForMixpanelQueues];
     
     XCTestExpectation *expect = [self expectationWithDescription:@"decide variants tracked"];
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{

--- a/HelloMixpanel/HelloMixpanelTests/HelloMixpanelTests.m
+++ b/HelloMixpanel/HelloMixpanelTests/HelloMixpanelTests.m
@@ -151,6 +151,9 @@
 }
 
 - (void)testIdentify {
+    // stub needed because reset flushes
+    stubTrack();
+    stubEngage();
     for (NSInteger i = 0; i < 2; i++) { // run this twice to test reset works correctly wrt to distinct ids
         NSString *distinctId = @"d1";
         // try this for IFA, ODIN and nil
@@ -396,6 +399,9 @@
 }
 
 - (void)testReset {
+    // stub needed because reset flushes
+    stubTrack();
+    stubEngage();
     [self.mixpanel identify:@"d1"];
     [self.mixpanel track:@"e1"];
     

--- a/HelloMixpanel/HelloMixpanelTests/MPNetworkTests.m
+++ b/HelloMixpanel/HelloMixpanelTests/MPNetworkTests.m
@@ -23,7 +23,7 @@
     [super setUp];
     
     NSURL *serverURL = [NSURL URLWithString:@"http://localhost:31337"];
-    self.network = [[MPNetwork alloc] initWithServerURL:serverURL];
+    self.network = [[MPNetwork alloc] initWithServerURL:serverURL mixpanel:nil];
 }
 
 - (void)tearDown {

--- a/HelloMixpanel/HelloMixpanelTests/MixpanelBaseTests.h
+++ b/HelloMixpanel/HelloMixpanelTests/MixpanelBaseTests.h
@@ -22,8 +22,8 @@
 @property (nonatomic, strong) Mixpanel *mixpanel;
 @property (atomic) BOOL mixpanelWillFlush;
 
-- (void)flushAndWaitForSerialQueue;
-- (void)waitForSerialQueue;
+- (void)flushAndWaitForMixpanelQueues;
+- (void)waitForMixpanelQueues;
 - (void)waitForAsyncQueue;
 
 - (UIViewController *)topViewController;

--- a/HelloMixpanel/HelloMixpanelTests/MixpanelBaseTests.m
+++ b/HelloMixpanel/HelloMixpanelTests/MixpanelBaseTests.m
@@ -23,7 +23,7 @@
                                       launchOptions:nil
                                    andFlushInterval:60];
     [self.mixpanel reset];
-    [self waitForSerialQueue];
+    [self waitForMixpanelQueues];
 }
 
 - (void)tearDown {
@@ -42,13 +42,15 @@
 }
 
 #pragma mark - Test Helpers
-- (void)flushAndWaitForSerialQueue {
+- (void)flushAndWaitForMixpanelQueues {
     [self.mixpanel flush];
-    [self waitForSerialQueue];
+    [self waitForMixpanelQueues];
 }
 
-- (void)waitForSerialQueue {
-    dispatch_sync(self.mixpanel.serialQueue, ^{ return; });
+- (void)waitForMixpanelQueues {
+    dispatch_sync(self.mixpanel.serialQueue, ^{
+        dispatch_sync(self.mixpanel.networkQueue, ^{ return; });
+    });
 }
 
 - (void)waitForAsyncQueue {

--- a/HelloMixpanel/HelloMixpanelTests/MixpanelBaseTests.m
+++ b/HelloMixpanel/HelloMixpanelTests/MixpanelBaseTests.m
@@ -22,8 +22,12 @@
     self.mixpanel = [[Mixpanel alloc] initWithToken:kTestToken
                                       launchOptions:nil
                                    andFlushInterval:60];
+    // stub track and engage temporarily because reset flushes. unstub after
+    stubTrack();
+    stubEngage();
     [self.mixpanel reset];
     [self waitForMixpanelQueues];
+    [[LSNocilla sharedInstance] clearStubs];
 }
 
 - (void)tearDown {

--- a/HelloMixpanel/HelloMixpanelTests/MixpanelPeopleTests.m
+++ b/HelloMixpanel/HelloMixpanelTests/MixpanelPeopleTests.m
@@ -21,7 +21,7 @@
     for (NSInteger i = 0; i < 505; i++) {
         [self.mixpanel.people set:@"i" to:@(i)];
     }
-    [self waitForSerialQueue];
+    [self waitForMixpanelQueues];
     XCTAssertTrue(self.mixpanel.people.unidentifiedQueue.count == 500);
     
     NSDictionary *r = self.mixpanel.people.unidentifiedQueue.firstObject;
@@ -36,7 +36,7 @@
     for (NSInteger i = 0; i < 505; i++) {
         [self.mixpanel.people set:@"i" to:@(i)];
     }
-    [self waitForSerialQueue];
+    [self waitForMixpanelQueues];
     XCTAssertTrue(self.mixpanel.peopleQueue.count == 500);
     
     NSDictionary *r = self.mixpanel.peopleQueue.firstObject;
@@ -59,7 +59,7 @@
     [self.mixpanel identify:@"d1"];
     NSData *token = [@"0123456789abcdef" dataUsingEncoding:NSUTF8StringEncoding];
     [self.mixpanel.people addPushDeviceToken:token];
-    [self waitForSerialQueue];
+    [self waitForMixpanelQueues];
     XCTAssertTrue(self.mixpanel.peopleQueue.count == 1, @"people records not queued");
     
     NSDictionary *p = self.mixpanel.peopleQueue.lastObject[@"$union"];
@@ -75,7 +75,7 @@
     [self.mixpanel identify:@"d1"];
     NSDictionary *p = @{ @"p1": @"a" };
     [self.mixpanel.people set:p];
-    [self waitForSerialQueue];
+    [self waitForMixpanelQueues];
     
     p = self.mixpanel.peopleQueue.lastObject[@"$set"];
     XCTAssertEqualObjects(p[@"p1"], @"a", @"custom people property not queued");
@@ -86,7 +86,7 @@
     [self.mixpanel identify:@"d1"];
     NSDictionary *p = @{@"p1": @"a"};
     [self.mixpanel.people setOnce:p];
-    [self waitForSerialQueue];
+    [self waitForMixpanelQueues];
     
     p = self.mixpanel.peopleQueue.lastObject[@"$set_once"];
     XCTAssertEqualObjects(p[@"p1"], @"a", @"custom people property not queued");
@@ -97,7 +97,7 @@
     [self.mixpanel identify:@"d1"];
     NSDictionary *p = @{@"$ios_app_version": @"override"};
     [self.mixpanel.people set:p];
-    [self waitForSerialQueue];
+    [self waitForMixpanelQueues];
     
     p = self.mixpanel.peopleQueue.lastObject[@"$set"];
     XCTAssertEqualObjects(p[@"$ios_app_version"], @"override", @"reserved property override failed");
@@ -107,7 +107,7 @@
 - (void)testPeopleSetTo {
     [self.mixpanel identify:@"d1"];
     [self.mixpanel.people set:@"p1" to:@"a"];
-    [self waitForSerialQueue];
+    [self waitForMixpanelQueues];
     
     NSDictionary *p = self.mixpanel.peopleQueue.lastObject[@"$set"];
     XCTAssertEqualObjects(p[@"p1"], @"a", @"custom people property not queued");
@@ -118,7 +118,7 @@
     [self.mixpanel identify:@"d1"];
     NSDictionary *p = @{ @"p1": @3 };
     [self.mixpanel.people increment:p];
-    [self waitForSerialQueue];
+    [self waitForMixpanelQueues];
     
     p = self.mixpanel.peopleQueue.lastObject[@"$add"];
     XCTAssertTrue(p.count == 1, @"incorrect people properties: %@", p);
@@ -129,7 +129,7 @@
 {
     [self.mixpanel identify:@"d1"];
     [self.mixpanel.people increment:@"p1" by:@3];
-    [self waitForSerialQueue];
+    [self waitForMixpanelQueues];
     
     NSDictionary *p = self.mixpanel.peopleQueue.lastObject[@"$add"];
     XCTAssertTrue(p.count == 1, @"incorrect people properties: %@", p);
@@ -140,7 +140,7 @@
 {
     [self.mixpanel identify:@"d1"];
     [self.mixpanel.people deleteUser];
-    [self waitForSerialQueue];
+    [self waitForMixpanelQueues];
     
     NSDictionary *p = self.mixpanel.peopleQueue.lastObject[@"$delete"];
     XCTAssertTrue(p.count == 0, @"incorrect people properties: %@", p);
@@ -150,7 +150,7 @@
 - (void)testPeopleTrackChargeDecimal {
     [self.mixpanel identify:@"d1"];
     [self.mixpanel.people trackCharge:@25.34];
-    [self waitForSerialQueue];
+    [self waitForMixpanelQueues];
     
     NSDictionary *r = self.mixpanel.peopleQueue.lastObject;
     XCTAssertEqualObjects(r[@"$append"][@"$transactions"][@"$amount"], @25.34);
@@ -169,7 +169,7 @@
 - (void)testPeopleTrackChargeZero {
     [self.mixpanel identify:@"d1"];
     [self.mixpanel.people trackCharge:@0];
-    [self waitForSerialQueue];
+    [self waitForMixpanelQueues];
     
     NSDictionary *r = self.mixpanel.peopleQueue.lastObject;
     XCTAssertEqualObjects(r[@"$append"][@"$transactions"][@"$amount"], @0);
@@ -180,7 +180,7 @@
     [self.mixpanel identify:@"d1"];
     NSDictionary *p = [self allPropertyTypes];
     [self.mixpanel.people trackCharge:@25 withProperties:@{@"$time": p[@"date"]}];
-    [self waitForSerialQueue];
+    [self waitForMixpanelQueues];
     
     NSDictionary *r = self.mixpanel.peopleQueue.lastObject;
     XCTAssertEqualObjects(r[@"$append"][@"$transactions"][@"$amount"], @25);
@@ -190,7 +190,7 @@
 - (void)testPeopleTrackChargeWithProperties {
     [self.mixpanel identify:@"d1"];
     [self.mixpanel.people trackCharge:@25 withProperties:@{@"p1": @"a"}];
-    [self waitForSerialQueue];
+    [self waitForMixpanelQueues];
     
     NSDictionary *r = self.mixpanel.peopleQueue.lastObject;
     XCTAssertEqualObjects(r[@"$append"][@"$transactions"][@"$amount"], @25);
@@ -200,7 +200,7 @@
 - (void)testPeopleTrackCharge {
     [self.mixpanel identify:@"d1"];
     [self.mixpanel.people trackCharge:@25];
-    [self waitForSerialQueue];
+    [self waitForMixpanelQueues];
     
     NSDictionary *r = self.mixpanel.peopleQueue.lastObject;
     XCTAssertEqualObjects(r[@"$append"][@"$transactions"][@"$amount"], @25);
@@ -210,7 +210,7 @@
 - (void)testPeopleClearCharges {
     [self.mixpanel identify:@"d1"];
     [self.mixpanel.people clearCharges];
-    [self waitForSerialQueue];
+    [self waitForMixpanelQueues];
     
     NSDictionary *r = self.mixpanel.peopleQueue.lastObject;
     XCTAssertEqualObjects(r[@"$set"][@"$transactions"], @[]);

--- a/Mixpanel/MPNetwork.h
+++ b/Mixpanel/MPNetwork.h
@@ -8,6 +8,8 @@
 
 #import <Foundation/Foundation.h>
 
+@class Mixpanel;
+
 typedef NS_ENUM(NSUInteger, MPNetworkEndpoint) {
     MPNetworkEndpointTrack,
     MPNetworkEndpointEngage,
@@ -19,7 +21,7 @@ typedef NS_ENUM(NSUInteger, MPNetworkEndpoint) {
 @property (nonatomic) BOOL shouldManageNetworkActivityIndicator;
 @property (nonatomic) BOOL useIPAddressForGeoLocation;
 
-- (instancetype)initWithServerURL:(NSURL *)serverURL;
+- (instancetype)initWithServerURL:(NSURL *)serverURL mixpanel:(Mixpanel *)mixpanel;
 
 - (void)flushEventQueue:(NSArray *)events;
 - (void)flushPeopleQueue:(NSArray *)people;

--- a/Mixpanel/MPNetworkPrivate.h
+++ b/Mixpanel/MPNetworkPrivate.h
@@ -10,6 +10,7 @@
 
 @interface MPNetwork ()
 
+@property (nonatomic, weak) Mixpanel *mixpanel;
 @property (nonatomic, strong) NSURL *serverURL;
 
 @property (nonatomic) NSTimeInterval requestsDisabledUntilTime;

--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -120,6 +120,8 @@ static NSString *defaultProjectToken;
 #endif
         NSString *label = [NSString stringWithFormat:@"com.mixpanel.%@.%p", apiToken, (void *)self];
         self.serialQueue = dispatch_queue_create([label UTF8String], DISPATCH_QUEUE_SERIAL);
+        NSString *networkLabel = [label stringByAppendingString:@".network"];
+        self.networkQueue = dispatch_queue_create([networkLabel UTF8String], DISPATCH_QUEUE_SERIAL);
 
         self.showSurveyOnActive = YES;
 #if defined(DISABLE_MIXPANEL_AB_DESIGNER) // Deprecated in v3.0.1
@@ -128,7 +130,7 @@ static NSString *defaultProjectToken;
         self.enableVisualABTestAndCodeless = YES;
 #endif
         
-        self.network = [[MPNetwork alloc] initWithServerURL:[NSURL URLWithString:self.serverURL]];
+        self.network = [[MPNetwork alloc] initWithServerURL:[NSURL URLWithString:self.serverURL] mixpanel:self];
         self.people = [[MixpanelPeople alloc] initWithMixpanel:self];
 
         [self setUpListeners];
@@ -283,7 +285,9 @@ static NSString *defaultProjectToken;
         if (self.people.unidentifiedQueue.count > 0) {
             for (NSMutableDictionary *r in self.people.unidentifiedQueue) {
                 r[@"$distinct_id"] = distinctId;
-                [self.peopleQueue addObject:r];
+                @synchronized (self) {
+                    [self.peopleQueue addObject:r];
+                }
             }
             [self.people.unidentifiedQueue removeAllObjects];
             [self archivePeople];
@@ -366,11 +370,13 @@ static NSString *defaultProjectToken;
         
         NSDictionary *e = @{ @"event": event, @"properties": [NSDictionary dictionaryWithDictionary:p]} ;
         MPLogInfo(@"%@ queueing event: %@", self, e);
-        [self.eventsQueue addObject:e];
-        if (self.eventsQueue.count > 5000) {
-            [self.eventsQueue removeObjectAtIndex:0];
+        @synchronized (self) {
+            [self.eventsQueue addObject:e];
+            if (self.eventsQueue.count > 5000) {
+                [self.eventsQueue removeObjectAtIndex:0];
+            }
         }
-        
+
         // Always archive
         [self archiveEvents];
     });
@@ -482,7 +488,15 @@ static NSString *defaultProjectToken;
 
 - (void)reset
 {
+    // TODO: maybe flush here as otherwise events could be lost?
     dispatch_async(self.serialQueue, ^{
+        // wait for all current network requests to finish before resetting
+        dispatch_semaphore_t networkWaitSemaphore = dispatch_semaphore_create(0);
+        dispatch_async(self.networkQueue, ^{
+            dispatch_semaphore_signal(networkWaitSemaphore);
+        });
+        dispatch_semaphore_wait(networkWaitSemaphore, DISPATCH_TIME_FOREVER);
+
         self.distinctId = [self defaultDistinctId];
         self.superProperties = [NSMutableDictionary dictionary];
         self.people.distinctId = nil;
@@ -499,11 +513,21 @@ static NSString *defaultProjectToken;
     });
 }
 
+- (void)dispatchOnNetworkQueue:(void (^)(void))dispatchBlock {
+    // so this looks stupid but to make [Mixpanel track]; [Mixpanel flush]; continue to have the track
+    // guaranteed to be part of the flush we need to make networkQueue stuff be dispatched on serialQueue
+    // first. still will allow serialQueue stuff to happen at the same time as networkQueue stuff just
+    // don't want to change track -> flush behavior that people may be relying on
+    dispatch_async(self.serialQueue, ^{
+        dispatch_async(self.networkQueue, dispatchBlock);
+    });
+}
+
 #pragma mark - Network control
 - (void)setServerURL:(NSString *)serverURL
 {
     _serverURL = serverURL.copy;
-    self.network = [[MPNetwork alloc] initWithServerURL:[NSURL URLWithString:serverURL]];
+    self.network = [[MPNetwork alloc] initWithServerURL:[NSURL URLWithString:serverURL] mixpanel:self];
 }
 
 - (NSUInteger)flushInterval {
@@ -552,7 +576,7 @@ static NSString *defaultProjectToken;
 
 - (void)flushWithCompletion:(void (^)())handler
 {
-    dispatch_async(self.serialQueue, ^{
+    [self dispatchOnNetworkQueue:^{
         MPLogInfo(@"%@ flush starting", self);
 
         __strong id<MixpanelDelegate> strongDelegate = self.delegate;
@@ -562,17 +586,18 @@ static NSString *defaultProjectToken;
                 return;
             }
         }
-        
+
         [self.network flushEventQueue:self.eventsQueue];
         [self.network flushPeopleQueue:self.peopleQueue];
+
         [self archive];
-        
+
         if (handler) {
             dispatch_async(dispatch_get_main_queue(), handler);
         }
 
         MPLogInfo(@"%@ flush complete", self);
-    });
+    }];
 }
 
 #pragma mark - Persistence
@@ -624,54 +649,64 @@ static NSString *defaultProjectToken;
 
 - (void)archiveEvents
 {
-    NSString *filePath = [self eventsFilePath];
-    NSMutableArray *eventsQueueCopy = [NSMutableArray arrayWithArray:[self.eventsQueue copy]];
-    MPLogInfo(@"%@ archiving events data to %@: %@", self, filePath, eventsQueueCopy);
-    if (![self archiveObject:eventsQueueCopy withFilePath:filePath]) {
-        MPLogError(@"%@ unable to archive event data", self);
+    @synchronized (self) {
+        NSString *filePath = [self eventsFilePath];
+        NSMutableArray *eventsQueueCopy = [self.eventsQueue mutableCopy];
+        MPLogInfo(@"%@ archiving events data to %@: %@", self, filePath, eventsQueueCopy);
+        if (![self archiveObject:eventsQueueCopy withFilePath:filePath]) {
+            MPLogError(@"%@ unable to archive event data", self);
+        }
     }
 }
 
 - (void)archivePeople
 {
-    NSString *filePath = [self peopleFilePath];
-    NSMutableArray *peopleQueueCopy = [NSMutableArray arrayWithArray:[self.peopleQueue copy]];
-    MPLogInfo(@"%@ archiving people data to %@: %@", self, filePath, peopleQueueCopy);
-    if (![self archiveObject:peopleQueueCopy withFilePath:filePath]) {
-        MPLogError(@"%@ unable to archive people data", self);
+    @synchronized (self) {
+        NSString *filePath = [self peopleFilePath];
+        NSMutableArray *peopleQueueCopy = [self.peopleQueue mutableCopy];
+        MPLogInfo(@"%@ archiving people data to %@: %@", self, filePath, peopleQueueCopy);
+        if (![self archiveObject:peopleQueueCopy withFilePath:filePath]) {
+            MPLogError(@"%@ unable to archive people data", self);
+        }
     }
 }
 
 - (void)archiveProperties
 {
-    NSString *filePath = [self propertiesFilePath];
-    NSMutableDictionary *p = [NSMutableDictionary dictionary];
-    [p setValue:self.distinctId forKey:@"distinctId"];
-    [p setValue:self.superProperties forKey:@"superProperties"];
-    [p setValue:self.people.distinctId forKey:@"peopleDistinctId"];
-    [p setValue:self.people.unidentifiedQueue forKey:@"peopleUnidentifiedQueue"];
-    [p setValue:self.shownSurveyCollections forKey:@"shownSurveyCollections"];
-    [p setValue:self.shownNotifications forKey:@"shownNotifications"];
-    [p setValue:self.timedEvents forKey:@"timedEvents"];
-    MPLogInfo(@"%@ archiving properties data to %@: %@", self, filePath, p);
-    if (![self archiveObject:p withFilePath:filePath]) {
-        MPLogError(@"%@ unable to archive properties data", self);
+    @synchronized (self) {
+        NSString *filePath = [self propertiesFilePath];
+        NSMutableDictionary *p = [NSMutableDictionary dictionary];
+        [p setValue:self.distinctId forKey:@"distinctId"];
+        [p setValue:self.superProperties forKey:@"superProperties"];
+        [p setValue:self.people.distinctId forKey:@"peopleDistinctId"];
+        [p setValue:self.people.unidentifiedQueue forKey:@"peopleUnidentifiedQueue"];
+        [p setValue:self.shownSurveyCollections forKey:@"shownSurveyCollections"];
+        [p setValue:self.shownNotifications forKey:@"shownNotifications"];
+        [p setValue:self.timedEvents forKey:@"timedEvents"];
+        MPLogInfo(@"%@ archiving properties data to %@: %@", self, filePath, p);
+        if (![self archiveObject:p withFilePath:filePath]) {
+            MPLogError(@"%@ unable to archive properties data", self);
+        }
     }
 }
 
 - (void)archiveVariants
 {
-    NSString *filePath = [self variantsFilePath];
-    if (![self archiveObject:self.variants withFilePath:filePath]) {
-        MPLogError(@"%@ unable to archive variants data", self);
+    @synchronized (self) {
+        NSString *filePath = [self variantsFilePath];
+        if (![self archiveObject:self.variants withFilePath:filePath]) {
+            MPLogError(@"%@ unable to archive variants data", self);
+        }
     }
 }
 
 - (void)archiveEventBindings
 {
-    NSString *filePath = [self eventBindingsFilePath];
-    if (![self archiveObject:self.eventBindings withFilePath:filePath]) {
-        MPLogError(@"%@ unable to archive tracking events data", self);
+    @synchronized (self) {
+        NSString *filePath = [self eventBindingsFilePath];
+        if (![self archiveObject:self.eventBindings withFilePath:filePath]) {
+            MPLogError(@"%@ unable to archive tracking events data", self);
+        }
     }
 }
 
@@ -1210,7 +1245,7 @@ static void MixpanelReachabilityCallback(SCNetworkReachabilityRef target, SCNetw
 
 - (void)checkForDecideResponseWithCompletion:(void (^)(NSArray *surveys, NSArray *notifications, NSSet *variants, NSSet *eventBindings))completion useCache:(BOOL)useCache
 {
-    dispatch_async(self.serialQueue, ^{
+    [self dispatchOnNetworkQueue:^{
         NSMutableSet *newVariants = [NSMutableSet set];
         NSMutableSet *newEventBindings = [NSMutableSet set];
         __block BOOL hadError = NO;
@@ -1218,19 +1253,19 @@ static void MixpanelReachabilityCallback(SCNetworkReachabilityRef target, SCNetw
         if (!useCache || !self.decideResponseCached) {
             // Build a proper URL from our parameters
             NSArray *queryItems = [MPNetwork buildDecideQueryForProperties:self.people.automaticPeopleProperties
-                                                                              withDistinctID:self.people.distinctId ?: self.distinctId
-                                                                                    andToken:self.apiToken];
-            
-            
+                                                            withDistinctID:self.people.distinctId ?: self.distinctId
+                                                                  andToken:self.apiToken];
+
+
             // Build a network request from the URL
             NSURLRequest *request = [self.network buildGetRequestForEndpoint:MPNetworkEndpointDecide
                                                               withQueryItems:queryItems];
-            
+
             // Send the network request
             dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
             [[[MPNetwork sharedURLSession] dataTaskWithRequest:request completionHandler:^(NSData *responseData,
-                                                                      NSURLResponse *urlResponse,
-                                                                      NSError *error) {
+                                                                                           NSURLResponse *urlResponse,
+                                                                                           NSError *error) {
 
                 if (error) {
                     MPLogError(@"%@ decide check http error: %@", self, error);
@@ -1350,20 +1385,20 @@ static void MixpanelReachabilityCallback(SCNetworkReachabilityRef target, SCNetw
                 // New bindings are those we are running for the first time.
                 [newEventBindings unionSet:parsedEventBindings];
                 [newEventBindings minusSet:self.eventBindings];
-                
+
                 NSMutableSet *allEventBindings = [self.eventBindings mutableCopy];
                 [allEventBindings unionSet:newEventBindings];
-                
+
                 self.surveys = [NSArray arrayWithArray:parsedSurveys];
                 self.notifications = [NSArray arrayWithArray:parsedNotifications];
                 self.variants = [allVariants copy];
                 self.eventBindings = [allEventBindings copy];
-                
+
                 self.decideResponseCached = YES;
 
                 dispatch_semaphore_signal(semaphore);
             }] resume];
-            
+
             dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
 
         } else {
@@ -1393,7 +1428,7 @@ static void MixpanelReachabilityCallback(SCNetworkReachabilityRef target, SCNetw
                 completion(unseenSurveys, unseenNotifications, newVariants, newEventBindings);
             }
         }
-    });
+    }];
 }
 
 - (void)checkForSurveysWithCompletion:(void (^)(NSArray *surveys))completion MIXPANEL_SURVEYS_DEPRECATED
@@ -1539,10 +1574,10 @@ static void MixpanelReachabilityCallback(SCNetworkReachabilityRef target, SCNetw
             }
             i++;
         }
-        
-        dispatch_async(_serialQueue, ^{
+
+        [self dispatchOnNetworkQueue:^{
             [self.network flushPeopleQueue:self.peopleQueue];
-        });
+        }];
     }
 }
 

--- a/Mixpanel/MixpanelPeople.m
+++ b/Mixpanel/MixpanelPeople.m
@@ -102,9 +102,11 @@
             if (self.distinctId) {
                 r[@"$distinct_id"] = self.distinctId;
                 MPLogInfo(@"%@ queueing people record: %@", self.mixpanel, r);
-                [strongMixpanel.peopleQueue addObject:r];
-                if (strongMixpanel.peopleQueue.count > 500) {
-                    [strongMixpanel.peopleQueue removeObjectAtIndex:0];
+                @synchronized (self) {
+                    [strongMixpanel.peopleQueue addObject:r];
+                    if (strongMixpanel.peopleQueue.count > 500) {
+                        [strongMixpanel.peopleQueue removeObjectAtIndex:0];
+                    }
                 }
             } else {
                 MPLogInfo(@"%@ queueing unidentified people record: %@", self.mixpanel, r);

--- a/Mixpanel/MixpanelPeople.m
+++ b/Mixpanel/MixpanelPeople.m
@@ -102,7 +102,7 @@
             if (self.distinctId) {
                 r[@"$distinct_id"] = self.distinctId;
                 MPLogInfo(@"%@ queueing people record: %@", self.mixpanel, r);
-                @synchronized (self) {
+                @synchronized (strongMixpanel) {
                     [strongMixpanel.peopleQueue addObject:r];
                     if (strongMixpanel.peopleQueue.count > 500) {
                         [strongMixpanel.peopleQueue removeObjectAtIndex:0];

--- a/Mixpanel/MixpanelPrivate.h
+++ b/Mixpanel/MixpanelPrivate.h
@@ -84,6 +84,7 @@
 @property (nonatomic, strong) NSMutableArray *eventsQueue;
 @property (nonatomic, strong) NSMutableArray *peopleQueue;
 @property (nonatomic) dispatch_queue_t serialQueue;
+@property (nonatomic) dispatch_queue_t networkQueue;
 @property (nonatomic, strong) NSMutableDictionary *timedEvents;
 
 @property (nonatomic) BOOL decideResponseCached;


### PR DESCRIPTION
here's my notes:

goal: non-network and network happen in parallel
non-network puts stuff in eventsQueue and peopleQueue
flush takes stuff out of eventsQueue and peopleQueue
need to lock on adding, removing, reading
need to lock on saving to disk (reading actually only happens on init so should be okay though maybe should do it anyway)
as it stands flush will flush whatever was added before. naively changing makes it so it will continue flushing as long as stuff keeps getting added in. should read all stuff at start to not have endless flushing
reset needs to wait on flushes as well
flush and other network queue stuff should be dispatched from the serial queue so the pattern of track -> flush always has that track in the flush instead of only sometimes… so everything on the network queue is dispatched through the serial queue…