### PR TITLE
Don't set queryItems if they're nil

### DIFF
--- a/Mixpanel/MPNetwork.m
+++ b/Mixpanel/MPNetwork.m
@@ -193,7 +193,9 @@ static const NSUInteger kBatchSize = 50;
     NSURL *urlWithEndpoint = [self.serverURL URLByAppendingPathComponent:endpoint];
     NSURLComponents *components = [NSURLComponents componentsWithURL:urlWithEndpoint
                                              resolvingAgainstBaseURL:YES];
-    components.queryItems = queryItems;
+    if (queryItems) {
+        components.queryItems = queryItems;
+    }
 
     // NSURLComponents/NSURLQueryItem doesn't encode + as %2B, and then the + is interpreted as a space on servers
     components.percentEncodedQuery = [components.percentEncodedQuery stringByReplacingOccurrencesOfString:@"+" withString:@"%2B"];


### PR DESCRIPTION
Hello, 

According to the documentation: “Passing nil to setQueryItems removes the query component of the NSURLComponents object.”

If the serverUrl is custom and it already has query parameters, they will be overridden when setting queryItems to nil, that’s the situation in my company, so I guess that it could potentially happen to someone else.

With this change we should not modify current behavior and we’ll allow developers to use query parameters in their serverUrl

Thank you so much for your time.