### PR TITLE
Reset MPTweakStore on Mixpanel#reset

### DIFF
--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -519,6 +519,9 @@ static NSString *defaultProjectToken;
         self.decideResponseCached = NO;
         self.variants = [NSSet set];
         self.eventBindings = [NSSet set];
+#if !MIXPANEL_NO_NOTIFICATION_AB_TEST_SUPPORT
+        [[MPTweakStore sharedInstance] reset];
+#endif
         [self archive];
     });
 }

--- a/Mixpanel/MixpanelPrivate.h
+++ b/Mixpanel/MixpanelPrivate.h
@@ -37,6 +37,7 @@
 #import "MPNotificationViewController.h"
 #import "MPSurveyNavigationController.h"
 #import "MPSwizzler.h"
+#import "MPTweakStore.h"
 #import "MPVariant.h"
 #import "MPWebSocket.h"
 #endif


### PR DESCRIPTION
Here is an issue @peymano and I have found and debugged together.

---

**Given** you have two boolean tweak variables. One of them is true by default, and another one is false.

```objective-c
MPTweakValue(@"test1", YES);
MPTweakValue(@"test2", NO);
```

**Given** on Mixpanel's website we run A/B test with two variants:
* Variant 1: `test1: NO; test2: YES`.
* Variant 2: `test1: NO; test2: NO`

**Given** we have two users with Mixpanel profiles with different distinct_ids. User1 got Variant 1 and User2 got Variant 2.

1. In our mobile app sign in as user 1 and call `Mixpanel#joinExperimentsWithCallback:`. If we happen to look into what `https://decide.mixpanel.com/decide?...` returns, it will have two tweaks:

```json
{
  "notifications": [],
  "surveys": [],
  "variants": [
    {
      "tweaks": [
        {
          "name": "test1",
          "encoding": "A",
          "default": true,
          "maximum": null,
          "value": false,
          "minimum": null,
          "type": "boolean"
        },
        {
          "name": "test2",
          "encoding": "A",
          "default": false,
          "maximum": null,
          "value": true,
          "minimum": null,
          "type": "boolean"
        }
      ],
      "actions": [],
      "id": 100,
      "experiment_id": 5
    }
  ]
}
```

2. Sign out from our app and sing in as User2. We get this user's `distinctId` from our server and we pass it to Mixpanel.

```objective-c
[self.mixpanel reset];
[self.mixpanel identify:distinctId];
```

3. We call `Mixpanel#joinExperimentsWithCallback:` to get User2's tweaks. If we happen to look into what `https://decide.mixpanel.com/decide?...` returns again, we will see that now it returns only one tweak for the variant. We assume it's because the other one's value matches with its default value.

```json
{
  "notifications": [],
  "surveys": [],
  "variants": [
    {
      "tweaks": [
        {
          "name": "test1",
          "encoding": "A",
          "default": true,
          "maximum": null,
          "value": false,
          "minimum": null,
          "type": "boolean"
        }
      ],
      "actions": [],
      "id": 101,
      "experiment_id": 5
    }
  ]
}
```

**Expected:** Variant 2, both tweaks are `NO`:

```objective-c
MPTweakValue(@"test1", YES); // NO
MPTweakValue(@"test2", NO); // NO
```

**Result:**

```objective-c
MPTweakValue(@"test1", YES); // NO
MPTweakValue(@"test2", NO); // YES
```

---

During the debugging @peymano and I have found out that `MPTweakStore#reset` never gets called during `Mixpanel#reset`. As a result previous tweak value in memory will be returned for User2 who should have had a different value (matching with tweak's default value).