### PR TITLE
Fix bug when using "Hide Text" option for in-apps

### DIFF
--- a/Mixpanel/MPNotification.m
+++ b/Mixpanel/MPNotification.m
@@ -25,7 +25,11 @@ NSString *const MPNotificationTypeTakeover = @"takeover";
             return nil;
         }
         
-        NSString *body = object[@"body"];
+        NSString *body = @"";
+        if (object[@"body"] != [NSNull null]) {
+            body = object[@"body"];
+        }
+        
         if (![body isKindOfClass:[NSString class]]) {
             [MPNotification logNotificationError:@"body" withValue:body];
             return nil;

--- a/Mixpanel/MPNotification.m
+++ b/Mixpanel/MPNotification.m
@@ -25,12 +25,12 @@ NSString *const MPNotificationTypeTakeover = @"takeover";
             return nil;
         }
         
-        NSString *body = @"";
+        NSString *body;
         if (object[@"body"] != [NSNull null]) {
             body = object[@"body"];
         }
         
-        if (![body isKindOfClass:[NSString class]]) {
+        if (!(body == nil || [body isKindOfClass:[NSString class]])) {
             [MPNotification logNotificationError:@"body" withValue:body];
             return nil;
         }

--- a/Mixpanel/MPTakeoverNotification.m
+++ b/Mixpanel/MPTakeoverNotification.m
@@ -12,7 +12,11 @@
 
 - (instancetype)initWithJSONObject:(NSDictionary *)jsonObject {
     if (self = [super initWithJSONObject:jsonObject]) {
-        NSString *title = jsonObject[@"title"];
+        NSString *title = @"";
+        if (jsonObject[@"title"] != [NSNull null]) {
+            title = jsonObject[@"title"];
+        }
+        
         if (![title isKindOfClass:[NSString class]]) {
             [MPNotification logNotificationError:@"title" withValue:title];
             return nil;

--- a/Mixpanel/MPTakeoverNotification.m
+++ b/Mixpanel/MPTakeoverNotification.m
@@ -12,12 +12,12 @@
 
 - (instancetype)initWithJSONObject:(NSDictionary *)jsonObject {
     if (self = [super initWithJSONObject:jsonObject]) {
-        NSString *title = @"";
+        NSString *title;
         if (jsonObject[@"title"] != [NSNull null]) {
             title = jsonObject[@"title"];
         }
         
-        if (![title isKindOfClass:[NSString class]]) {
+        if (!(title == nil || [title isKindOfClass:[NSString class]])) {
             [MPNotification logNotificationError:@"title" withValue:title];
             return nil;
         }


### PR DESCRIPTION
Currently, checking "Hide Text" will send null for the body and title which isn't an NSString and causes the notification not to be shown.