### PR TITLE
General warning fixes for v3.1.2

### DIFF
--- a/Mixpanel/MPNSAttributedStringToNSDictionaryValueTransformer.m
+++ b/Mixpanel/MPNSAttributedStringToNSDictionaryValueTransformer.m
@@ -22,9 +22,9 @@
         NSMutableAttributedString *attributedString = [value mutableCopy];
         [attributedString beginEditing];
         __block BOOL safe = NO;
-        [attributedString enumerateAttribute:NSParagraphStyleAttributeName inRange:NSMakeRange(0, attributedString.length) options:0 usingBlock:^(id value, NSRange range, BOOL *stop) {
-            if (value) {
-                NSParagraphStyle *paragraphStyle = value;
+        [attributedString enumerateAttribute:NSParagraphStyleAttributeName inRange:NSMakeRange(0, attributedString.length) options:0 usingBlock:^(id valueObject, NSRange range, BOOL *stop) {
+            if (valueObject) {
+                NSParagraphStyle *paragraphStyle = valueObject;
                 if([paragraphStyle respondsToSelector:@selector(headIndent)]) {
                     safe = YES;
                 }

--- a/Mixpanel/MPNetwork.m
+++ b/Mixpanel/MPNetwork.m
@@ -60,7 +60,8 @@ static const NSUInteger kBatchSize = 50;
 
     NSMutableArray *queueCopyForFlushing;
 
-    @synchronized (self.mixpanel) {
+    Mixpanel *mixpanel = self.mixpanel;
+    @synchronized (mixpanel) {
         queueCopyForFlushing = [queue mutableCopy];
     }
     
@@ -103,7 +104,7 @@ static const NSUInteger kBatchSize = 50;
             break;
         }
 
-        @synchronized (self.mixpanel) {
+        @synchronized (mixpanel) {
             [queueCopyForFlushing removeObjectsInArray:batch];
             [queue removeObjectsInArray:batch];
         }

--- a/Mixpanel/MPNotification.h
+++ b/Mixpanel/MPNotification.h
@@ -9,7 +9,7 @@ extern NSString *const MPNotificationTypeTakeover;
 @property (nonatomic, readonly) NSDictionary *extrasDescription;
 @property (nonatomic, readonly) NSUInteger ID;
 @property (nonatomic, readonly) NSUInteger messageID;
-@property (nonatomic) NSString *type;
+@property (nonatomic, readonly) NSString *type;
 @property (nonatomic, copy) NSURL *imageURL;
 @property (nonatomic, strong) NSData *image;
 @property (nonatomic, readonly) NSString *body;

--- a/Mixpanel/MPNotificationViewController.m
+++ b/Mixpanel/MPNotificationViewController.m
@@ -208,8 +208,9 @@
 }
 
 - (IBAction)tappedClose:(UITapGestureRecognizer *)gesture {
-    if ([self.delegate respondsToSelector:@selector(notificationController:wasDismissedWithCtaUrl:)]) {
-        [self.delegate notificationController:self wasDismissedWithCtaUrl:nil];
+    id<MPNotificationViewControllerDelegate> delegate = self.delegate;
+    if ([delegate respondsToSelector:@selector(notificationController:wasDismissedWithCtaUrl:)]) {
+        [delegate notificationController:self wasDismissedWithCtaUrl:nil];
     }
 }
 
@@ -403,10 +404,11 @@ static const NSUInteger MPMiniNotificationSpacingFromBottom = 10;
 
 - (void)didPan:(UIPanGestureRecognizer *)gesture {
     if (_canPan) {
+        UIViewController *parentViewController = self.parentViewController;
         if (gesture.state == UIGestureRecognizerStateBegan && gesture.numberOfTouches == 1) {
-            _panStartPoint = [gesture locationInView:self.parentViewController.view];
+            _panStartPoint = [gesture locationInView:parentViewController.view];
         } else if (gesture.state == UIGestureRecognizerStateChanged) {
-            CGPoint position = [gesture locationInView:self.parentViewController.view];
+            CGPoint position = [gesture locationInView:parentViewController.view];
             CGFloat diffY = position.y - _panStartPoint.y;
 
             if (diffY > 0) {

--- a/Mixpanel/Mixpanel.h
+++ b/Mixpanel/Mixpanel.h
@@ -368,7 +368,7 @@ NS_ASSUME_NONNULL_BEGIN
  one instace, it will return the first one that was created by using <code>sharedInstanceWithToken:</code> 
  or <code>initWithToken:launchOptions:andFlushInterval:</code>.
  */
-+ (Mixpanel *)sharedInstance;
++ (nullable Mixpanel *)sharedInstance;
 
 /*!
  @method

--- a/Mixpanel/MixpanelPeople.m
+++ b/Mixpanel/MixpanelPeople.m
@@ -106,7 +106,7 @@
 
             if (self.distinctId) {
                 r[@"$distinct_id"] = self.distinctId;
-                MPLogInfo(@"%@ queueing people record: %@", self.mixpanel, r);
+                MPLogInfo(@"%@ queueing people record: %@", strongMixpanel, r);
                 @synchronized (strongMixpanel) {
                     [strongMixpanel.peopleQueue addObject:r];
                     if (strongMixpanel.peopleQueue.count > 500) {


### PR DESCRIPTION
Good to hear that you are going to remove the survey deprecated code soon, The reason behind this PR is to eliminate/silence all the warnings from mixpanel code. Since the project I am involved in is treating warnings as errors (and hence those prevents compiling and running). Plus no warnings is a good thing :)

Anyways, I updated this PR to only include general warnings fixes.