### PR TITLE
Changes assert to NSAssert

### DIFF
--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -735,7 +735,7 @@ static NSString *defaultProjectToken;
 - (BOOL)addSkipBackupAttributeToItemAtPath:(NSString *)filePathString
 {
     NSURL *URL = [NSURL fileURLWithPath: filePathString];
-    assert([[NSFileManager defaultManager] fileExistsAtPath: [URL path]]);
+    NSAssert([[NSFileManager defaultManager] fileExistsAtPath: [URL path]]);
 
     NSError *error = nil;
     BOOL success = [URL setResourceValue: [NSNumber numberWithBool: YES]


### PR DESCRIPTION
Updates `assert()` to `NSAssert` as the rest of the assertion calls in the file.

This change prevents users from encountering the `Implicit declaration of function 'assert' is invalid in C99` on line 738 when compiling on some projects.