### PR TITLE
add a method to check elapsed time for a timed event

### DIFF
--- a/Mixpanel/Mixpanel.h
+++ b/Mixpanel/Mixpanel.h
@@ -577,6 +577,16 @@ NS_ASSUME_NONNULL_BEGIN
  @method
 
  @abstract
+ Retrieves the time elapsed for the named event since <code>timeEvent:</code> was called.
+
+ @param event   the name of the event to be tracked that was passed to <code>timeEvent:</code>
+ */
+- (double)eventElapsedTime:(NSString *)event;
+
+/*!
+ @method
+
+ @abstract
  Clears all current event timers.
  */
 - (void)clearTimedEvents;

--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -517,6 +517,15 @@ static NSString *defaultProjectToken;
     });
 }
 
+- (double)eventElapsedTime:(NSString *)event {
+    NSNumber *startTime = self.timedEvents[event];
+    if (!startTime) {
+        return 0;
+    } else {
+        return [[NSDate date] timeIntervalSince1970] - [startTime doubleValue];
+    }
+}
+
 - (void)clearTimedEvents
 {   dispatch_async(self.serialQueue, ^{
         self.timedEvents = [NSMutableDictionary dictionary];


### PR DESCRIPTION
https://github.com/mixpanel/mixpanel-iphone/issues/642

@yarneo i chose to allow them to check the current duration because it gives more flexibility for the user and also the other option would be a bit messy because we archive `timedEvents` so either the implementation wouldn't be clean or we'd have to have a way to migrate `timedEvents`