### PR TITLE
Support tracking journey_id for push open events

### DIFF
--- a/HelloMixpanel/HelloMixpanelTests/HelloMixpanelTests.m
+++ b/HelloMixpanel/HelloMixpanelTests/HelloMixpanelTests.m
@@ -325,7 +325,8 @@
     NSDictionary *launchOptions = @{ UIApplicationLaunchOptionsRemoteNotificationKey: @{
                                              @"mp": @{
                                                      @"m": @"the_message_id",
-                                                     @"c": @"the_campaign_id"
+                                                     @"c": @"the_campaign_id",
+                                                     @"journey_id": 123456
                                                      }
                                              }
                                      };
@@ -339,6 +340,7 @@
     NSDictionary *p = e[@"properties"];
     XCTAssertEqualObjects(p[@"campaign_id"], @"the_campaign_id", @"campaign_id not equal");
     XCTAssertEqualObjects(p[@"message_id"], @"the_message_id", @"message_id not equal");
+    XCTAssertEqualObjects(p[@"journey_id"], 123456, @"journey_id not equal");
     XCTAssertEqualObjects(p[@"message_type"], @"push", @"type does not equal inapp");
 }
 #endif

--- a/HelloMixpanel/HelloMixpanelTests/HelloMixpanelTests.m
+++ b/HelloMixpanel/HelloMixpanelTests/HelloMixpanelTests.m
@@ -326,7 +326,7 @@
                                              @"mp": @{
                                                      @"m": @"the_message_id",
                                                      @"c": @"the_campaign_id",
-                                                     @"journey_id": 123456
+                                                     @"journey_id": @123456
                                                      }
                                              }
                                      };
@@ -340,7 +340,7 @@
     NSDictionary *p = e[@"properties"];
     XCTAssertEqualObjects(p[@"campaign_id"], @"the_campaign_id", @"campaign_id not equal");
     XCTAssertEqualObjects(p[@"message_id"], @"the_message_id", @"message_id not equal");
-    XCTAssertEqualObjects(p[@"journey_id"], 123456, @"journey_id not equal");
+    XCTAssertEqualObjects(p[@"journey_id"], @123456, @"journey_id not equal");
     XCTAssertEqualObjects(p[@"message_type"], @"push", @"type does not equal inapp");
 }
 #endif

--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -434,9 +434,14 @@ static NSString *defaultProjectToken;
         NSDictionary *mpPayload = [rawMp isKindOfClass:[NSDictionary class]] ? rawMp : nil;
 
         if (mpPayload[@"m"] && mpPayload[@"c"]) {
-            [self track:event properties:@{@"campaign_id": mpPayload[@"c"],
-                                           @"message_id": mpPayload[@"m"],
-                                           @"message_type": @"push"}];
+            NSMutableDictionary *properties = [mpPayload mutableCopy];
+            properties[@"campaign_id"] = mpPayload[@"c"]
+            properties[@"message_id"] = mpPayload[@"m"]
+            properties[@"message_type"] = @"push"
+            [properties removeObjectForKey:@"c"]
+            [properties removeObjectForKey:@"m"]
+
+            [self track:event properties:properties];
         } else {
             MPLogInfo(@"%@ malformed mixpanel push payload %@", self, mpPayload);
         }

--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -435,11 +435,11 @@ static NSString *defaultProjectToken;
 
         if (mpPayload[@"m"] && mpPayload[@"c"]) {
             NSMutableDictionary *properties = [mpPayload mutableCopy];
-            properties[@"campaign_id"] = mpPayload[@"c"]
-            properties[@"message_id"] = mpPayload[@"m"]
-            properties[@"message_type"] = @"push"
-            [properties removeObjectForKey:@"c"]
-            [properties removeObjectForKey:@"m"]
+            properties[@"campaign_id"] = mpPayload[@"c"];
+            properties[@"message_id"] = mpPayload[@"m"];
+            properties[@"message_type"] = @"push";
+            [properties removeObjectForKey:@"c"];
+            [properties removeObjectForKey:@"m"];
 
             [self track:event properties:properties];
         } else {


### PR DESCRIPTION
### Current Format
#### Push payload
```
{
	‘mp’: {
                 ‘c’: $campaign_id,
 	         ‘m’: $message_id,
        }
}
```
 
#### Track call
```
{
	event: $campaign_received,
  	properties: {
		‘campaign_id': $campaign_id,
		‘message_id’: $message_id
	}
}
```
 
### New Format
#### Push payload
```
{
	‘mp’: {
                ‘c’: $campaign_id,
 	        ‘m’: $message_id,
		‘additional_params_1’: $param1,
	        ‘additional_params_2’: $param2,
        }
}
```
 
### Track call
```
{
	event: $campaign_received,
  	properties: {
		‘campaign_id': $campaign_id,
		‘message_id’: $message_id,
		‘additional_params_1’: $param1,
		‘additional_params_2’: $param2,
	}
}
```