### PR TITLE
use event's pointer for removing instead of isEqual to not remove ide…

### DIFF
--- a/Mixpanel/MPNetwork.m
+++ b/Mixpanel/MPNetwork.m
@@ -131,8 +131,16 @@ static const NSUInteger kBatchSize = 50;
         }
 
         @synchronized (mixpanel) {
-            [queueCopyForFlushing removeObjectsInArray:batch];
-            [queue removeObjectsInArray:batch];
+            for (NSDictionary *event in batch) {
+                NSUInteger index = [queueCopyForFlushing indexOfObjectIdenticalTo:event];
+                if (index != NSNotFound) {
+                    [queueCopyForFlushing removeObjectAtIndex:index];
+                }
+                index = [queue indexOfObjectIdenticalTo:event];
+                if (index != NSNotFound) {
+                    [queue removeObjectAtIndex:index];
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
…ntical events from the queue when flushing