### PR TITLE
Fix warnings when building in Xcode 9

### DIFF
--- a/Mixpanel/MPABTestDesignerConnection.h
+++ b/Mixpanel/MPABTestDesignerConnection.h
@@ -14,7 +14,7 @@ extern NSString *const kSessionVariantKey;
 @property (nonatomic, assign) BOOL sessionEnded;
 
 - (instancetype)initWithURL:(NSURL *)url;
-- (instancetype)initWithURL:(NSURL *)url keepTrying:(BOOL)keepTrying connectCallback:(void (^)())connectCallback disconnectCallback:(void (^)())disconnectCallback;
+- (instancetype)initWithURL:(NSURL *)url keepTrying:(BOOL)keepTrying connectCallback:(void (^)(void))connectCallback disconnectCallback:(void (^)(void))disconnectCallback;
 
 - (void)setSessionObject:(id)object forKey:(NSString *)key;
 - (id)sessionObjectForKey:(NSString *)key;

--- a/Mixpanel/MPABTestDesignerConnection.m
+++ b/Mixpanel/MPABTestDesignerConnection.m
@@ -43,11 +43,11 @@ static NSString * const kFinishLoadingAnimationKey = @"MPConnectivityBarFinishLo
     NSOperationQueue *_commandQueue;
     UIView *_recordingView;
     CALayer *_indeterminateLayer;
-    void (^_connectCallback)();
-    void (^_disconnectCallback)();
+    void (^_connectCallback)(void);
+    void (^_disconnectCallback)(void);
 }
 
-- (instancetype)initWithURL:(NSURL *)url keepTrying:(BOOL)keepTrying connectCallback:(void (^)())connectCallback disconnectCallback:(void (^)())disconnectCallback
+- (instancetype)initWithURL:(NSURL *)url keepTrying:(BOOL)keepTrying connectCallback:(void (^)(void))connectCallback disconnectCallback:(void (^)(void))disconnectCallback
 {
     self = [super init];
     if (self) {

--- a/Mixpanel/MPSwizzler.h
+++ b/Mixpanel/MPSwizzler.h
@@ -11,7 +11,7 @@
 // Cast to turn things that are not ids into NSMapTable keys
 #define MAPTABLE_ID(x) (__bridge id)((void *)x)
 
-typedef void (^swizzleBlock)();
+typedef void (^swizzleBlock)(void);
 
 @interface MPSwizzler : NSObject
 

--- a/Mixpanel/MPSwizzler.m
+++ b/Mixpanel/MPSwizzler.m
@@ -92,7 +92,7 @@ static void mp_swizzledMethod_5(id self, SEL _cmd, id arg, id arg2, id arg3)
     }
 }
 
-static void (*mp_swizzledMethods[MAX_ARGS - MIN_ARGS + 1])() = {mp_swizzledMethod_2, mp_swizzledMethod_3, mp_swizzledMethod_4, mp_swizzledMethod_5};
+static IMP mp_swizzledMethods[MAX_ARGS - MIN_ARGS + 1] =  {(IMP)mp_swizzledMethod_2, (IMP)mp_swizzledMethod_3, (IMP)mp_swizzledMethod_4, (IMP)mp_swizzledMethod_5};
 
 @implementation MPSwizzler
 
@@ -149,7 +149,7 @@ static void (*mp_swizzledMethods[MAX_ARGS - MIN_ARGS + 1])() = {mp_swizzledMetho
         if (numArgs >= MIN_ARGS && numArgs <= MAX_ARGS) {
                 
             BOOL isLocal = [self isLocallyDefinedMethod:aMethod onClass:aClass];
-            IMP swizzledMethod = (IMP)mp_swizzledMethods[numArgs - 2];
+            IMP swizzledMethod = mp_swizzledMethods[numArgs - 2];
             MPSwizzle *swizzle = [self swizzleForMethod:aMethod];
                 
             if (isLocal) {

--- a/Mixpanel/MPSwizzler.m
+++ b/Mixpanel/MPSwizzler.m
@@ -42,7 +42,7 @@ static void mp_swizzledMethod_2(id self, SEL _cmd)
         NSEnumerator *blocks = [swizzle.blocks objectEnumerator];
         swizzleBlock block;
         while ((block = [blocks nextObject])) {
-            block(self, _cmd);
+            ((void(^)(id, SEL))block)(self, _cmd);
         }
     }
 }
@@ -57,7 +57,7 @@ static void mp_swizzledMethod_3(id self, SEL _cmd, id arg)
         NSEnumerator *blocks = [swizzle.blocks objectEnumerator];
         swizzleBlock block;
         while ((block = [blocks nextObject])) {
-            block(self, _cmd, arg);
+            ((void(^)(id, SEL, id))block)(self, _cmd, arg);
         }
     }
 }
@@ -72,7 +72,7 @@ static void mp_swizzledMethod_4(id self, SEL _cmd, id arg, id arg2)
         NSEnumerator *blocks = [swizzle.blocks objectEnumerator];
         swizzleBlock block;
         while ((block = [blocks nextObject])) {
-            block(self, _cmd, arg, arg2);
+            ((void(^)(id, SEL, id, id))block)(self, _cmd, arg, arg2);
         }
     }
 }
@@ -87,7 +87,7 @@ static void mp_swizzledMethod_5(id self, SEL _cmd, id arg, id arg2, id arg3)
         NSEnumerator *blocks = [swizzle.blocks objectEnumerator];
         swizzleBlock block;
         while ((block = [blocks nextObject])) {
-            block(self, _cmd, arg, arg2, arg3);
+            ((void(^)(id, SEL, id, id, id))block)(self, _cmd, arg, arg2, arg3);
         }
     }
 }

--- a/Mixpanel/MPUIControlBinding.m
+++ b/Mixpanel/MPUIControlBinding.m
@@ -150,11 +150,11 @@
 
         [MPSwizzler swizzleSelector:NSSelectorFromString(@"didMoveToWindow")
                             onClass:self.swizzleClass
-                          withBlock:executeBlock
+                          withBlock:(swizzleBlock)executeBlock
                               named:self.name];
         [MPSwizzler swizzleSelector:NSSelectorFromString(@"didMoveToSuperview")
                             onClass:self.swizzleClass
-                          withBlock:executeBlock
+                          withBlock:(swizzleBlock)executeBlock
                               named:self.name];
         self.running = true;
     }

--- a/Mixpanel/MPUITableViewBinding.m
+++ b/Mixpanel/MPUITableViewBinding.m
@@ -92,7 +92,7 @@
 
         [MPSwizzler swizzleSelector:@selector(tableView:didSelectRowAtIndexPath:)
                             onClass:self.swizzleClass
-                          withBlock:block
+                          withBlock:(swizzleBlock)block
                               named:self.name];
         self.running = true;
     }

--- a/Mixpanel/MPVariant.m
+++ b/Mixpanel/MPVariant.m
@@ -456,7 +456,7 @@ static NSMapTable *originalCache;
 
     // The block that is called on swizzle executes the executeBlock on the main queue to minimize time
     // spent in the swizzle, and allow the newly added UI elements time to be initialized on screen.
-    void (^swizzleBlock)(id, SEL) = ^(id view, SEL command){
+    void (^swizzleExecuteBlock)(id, SEL) = ^(id view, SEL command){
         dispatch_async(dispatch_get_main_queue(), ^{ executeBlock(view, command);});
     };
 
@@ -464,7 +464,7 @@ static NSMapTable *originalCache;
         // Swizzle the method needed to check for this object coming onscreen
         [MPSwizzler swizzleSelector:self.swizzleSelector
                             onClass:self.swizzleClass
-                          withBlock:swizzleBlock
+                          withBlock:(swizzleBlock)swizzleExecuteBlock
                               named:self.name];
     }
 }

--- a/Mixpanel/Mixpanel.h
+++ b/Mixpanel/Mixpanel.h
@@ -628,7 +628,7 @@ NS_ASSUME_NONNULL_BEGIN
  are called when an app is brought to the background and require a handler to
  be called when it finishes.
  */
-- (void)flushWithCompletion:(nullable void (^)())handler;
+- (void)flushWithCompletion:(nullable void (^)(void))handler;
 
 /*!
  @method
@@ -746,7 +746,7 @@ NS_ASSUME_NONNULL_BEGIN
  Same as joinExperiments but will fire the given callback after all experiments
  have been loaded and applied.
  */
-- (void)joinExperimentsWithCallback:(nullable void (^)())experimentsLoadedCallback;
+- (void)joinExperimentsWithCallback:(nullable void (^)(void))experimentsLoadedCallback;
 
 #endif // MIXPANEL_NO_NOTIFICATION_AB_TEST_SUPPORT
 

--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -620,7 +620,7 @@ static NSString *defaultProjectToken;
     [self flushWithCompletion:nil];
 }
 
-- (void)flushWithCompletion:(void (^)())handler
+- (void)flushWithCompletion:(void (^)(void))handler
 {
     [self dispatchOnNetworkQueue:^{
         MPLogInfo(@"%@ flush starting", self);
@@ -1656,7 +1656,7 @@ static void MixpanelReachabilityCallback(SCNetworkReachabilityRef target, SCNetw
         return;
     }
 
-    void (^completionBlock)() = ^void() {
+    void (^completionBlock)(void) = ^void() {
         self.currentlyShowingNotification = nil;
         self.notificationViewController = nil;
     };
@@ -1765,7 +1765,7 @@ static void MixpanelReachabilityCallback(SCNetworkReachabilityRef target, SCNetw
                 [connection sendMessage:message];
             };
             
-            [MPSwizzler swizzleSelector:@selector(track:properties:) onClass:[Mixpanel class] withBlock:block named:@"track_properties"];
+            [MPSwizzler swizzleSelector:@selector(track:properties:) onClass:[Mixpanel class] withBlock:(swizzleBlock)block named:@"track_properties"];
         }
     };
     void (^disconnectCallback)(void) = ^{
@@ -1819,7 +1819,7 @@ static void MixpanelReachabilityCallback(SCNetworkReachabilityRef target, SCNetw
     [self track:@"$experiment_started" properties:@{@"$experiment_id": @(variant.experimentID), @"$variant_id": @(variant.ID)}];
 }
 
-- (void)joinExperimentsWithCallback:(void(^)())experimentsLoadedCallback
+- (void)joinExperimentsWithCallback:(void(^)(void))experimentsLoadedCallback
 {
     [self checkForVariantsWithCompletion:^(NSSet *newVariants) {
         for (MPVariant *variant in newVariants) {


### PR DESCRIPTION
This is basically a first stab at the strict prototypes related warnings
that where added in Xcode 9.

I've basically only confirmed that this compiles at this point - so it
should probably be tested to make sure no runtime errors are introduced
etc.