### PR TITLE
fix signal and exception handling

### DIFF
--- a/Mixpanel/Mixpanel.h
+++ b/Mixpanel/Mixpanel.h
@@ -339,7 +339,9 @@ NS_ASSUME_NONNULL_BEGIN
  @method
 
  @abstract
- Initializes an instance of the API with the given project token.
+ Initializes an instance of the API with the given project token. This also sets
+ it as a shared instance so you can use [Mixpanel sharedInstance] or
+ [Mixpanel sharedInstanceWithToken:apiToken] to retrieve this object later.
 
  @discussion
  Creates and initializes a new API object. See also <code>sharedInstanceWithToken:</code>.

--- a/Mixpanel/Mixpanel.h
+++ b/Mixpanel/Mixpanel.h
@@ -347,8 +347,30 @@ NS_ASSUME_NONNULL_BEGIN
  @param apiToken        your project token
  @param launchOptions   optional app delegate launchOptions
  @param flushInterval   interval to run background flushing
+ @param trackCrashes    whether or not to track crashes in Mixpanel. may want to disable if you're seeing
+                        issues with your crash reporting for either signals or exceptions
  */
-- (instancetype)initWithToken:(NSString *)apiToken launchOptions:(nullable NSDictionary *)launchOptions andFlushInterval:(NSUInteger)flushInterval;
+- (instancetype)initWithToken:(NSString *)apiToken
+                launchOptions:(nullable NSDictionary *)launchOptions
+                flushInterval:(NSUInteger)flushInterval
+                 trackCrashes:(BOOL)trackCrashes;
+
+/*!
+ @method
+
+ @abstract
+ Initializes an instance of the API with the given project token.
+
+ @discussion
+ Creates and initializes a new API object. See also <code>sharedInstanceWithToken:</code>.
+
+ @param apiToken        your project token
+ @param launchOptions   optional app delegate launchOptions
+ @param flushInterval   interval to run background flushing
+ */
+- (instancetype)initWithToken:(NSString *)apiToken
+                launchOptions:(nullable NSDictionary *)launchOptions
+             andFlushInterval:(NSUInteger)flushInterval;
 
 /*!
  @method

--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -35,8 +35,7 @@
 static NSMutableDictionary *instances;
 static NSString *defaultProjectToken;
 
-+ (Mixpanel *)sharedInstanceWithToken:(NSString *)apiToken launchOptions:(NSDictionary *)launchOptions
-{
++ (Mixpanel *)sharedInstanceWithToken:(NSString *)apiToken launchOptions:(NSDictionary *)launchOptions {
     if (instances[apiToken]) {
         return instances[apiToken];
     }
@@ -50,13 +49,11 @@ static NSString *defaultProjectToken;
     return [[self alloc] initWithToken:apiToken launchOptions:launchOptions andFlushInterval:flushInterval];
 }
 
-+ (Mixpanel *)sharedInstanceWithToken:(NSString *)apiToken
-{
++ (Mixpanel *)sharedInstanceWithToken:(NSString *)apiToken {
     return [Mixpanel sharedInstanceWithToken:apiToken launchOptions:nil];
 }
 
-+ (nullable Mixpanel *)sharedInstance
-{
++ (nullable Mixpanel *)sharedInstance {
     if (instances.count == 0) {
         MPLogWarning(@"sharedInstance called before creating a Mixpanel instance");
         return nil;
@@ -69,8 +66,7 @@ static NSString *defaultProjectToken;
     return instances[defaultProjectToken];
 }
 
-- (instancetype)init:(NSString *)apiToken
-{
+- (instancetype)init:(NSString *)apiToken {
     if (self = [super init]) {
         self.eventsQueue = [NSMutableArray array];
         self.peopleQueue = [NSMutableArray array];
@@ -87,8 +83,10 @@ static NSString *defaultProjectToken;
     return self;
 }
 
-- (instancetype)initWithToken:(NSString *)apiToken launchOptions:(NSDictionary *)launchOptions andFlushInterval:(NSUInteger)flushInterval
-{
+- (instancetype)initWithToken:(NSString *)apiToken
+                launchOptions:(NSDictionary *)launchOptions
+                flushInterval:(NSUInteger)flushInterval
+                 trackCrashes:(BOOL)trackCrashes {
     if (apiToken.length == 0) {
         if (apiToken == nil) {
             apiToken = @"";
@@ -97,8 +95,10 @@ static NSString *defaultProjectToken;
     }
     if (self = [self init:apiToken]) {
 #if !MIXPANEL_NO_AUTOMATIC_EVENTS_SUPPORT
-        // Install uncaught exception handlers first
-        [[MixpanelExceptionHandler sharedHandler] addMixpanelInstance:self];
+        if (trackCrashes) {
+            // Install signal and exception handlers first
+            [[MixpanelExceptionHandler sharedHandler] addMixpanelInstance:self];
+        }
 #endif
 #if !MIXPANEL_NO_REACHABILITY_SUPPORT
         self.telephonyInfo = [[CTTelephonyNetworkInfo alloc] init];
@@ -158,13 +158,20 @@ static NSString *defaultProjectToken;
     return self;
 }
 
-- (instancetype)initWithToken:(NSString *)apiToken andFlushInterval:(NSUInteger)flushInterval
-{
+- (instancetype)initWithToken:(NSString *)apiToken
+                launchOptions:(NSDictionary *)launchOptions
+             andFlushInterval:(NSUInteger)flushInterval {
+    return [self initWithToken:apiToken
+                 launchOptions:launchOptions
+                 flushInterval:flushInterval
+                  trackCrashes:YES];
+}
+
+- (instancetype)initWithToken:(NSString *)apiToken andFlushInterval:(NSUInteger)flushInterval {
     return [self initWithToken:apiToken launchOptions:nil andFlushInterval:flushInterval];
 }
 
-- (void)dealloc
-{
+- (void)dealloc {
     [[NSNotificationCenter defaultCenter] removeObserver:self];
     
 #if !MIXPANEL_NO_REACHABILITY_SUPPORT

--- a/Mixpanel/MixpanelExceptionHandler.m
+++ b/Mixpanel/MixpanelExceptionHandler.m
@@ -26,6 +26,7 @@ const NSInteger UncaughtExceptionHandlerReportAddressCount = 5;
 @interface MixpanelExceptionHandler ()
 
 @property (nonatomic) NSUncaughtExceptionHandler *defaultExceptionHandler;
+@property (nonatomic, unsafe_unretained) struct sigaction *prev_signal_handlers;
 @property (nonatomic, strong) NSHashTable *mixpanelInstances;
 
 @end
@@ -69,22 +70,36 @@ const NSInteger UncaughtExceptionHandlerReportAddressCount = 5;
         // Create a hash table of weak pointers to mixpanel instances
         _mixpanelInstances = [NSHashTable weakObjectsHashTable];
         
-        // Save the existing exception handler
-        _defaultExceptionHandler = NSGetUncaughtExceptionHandler();
+        _prev_signal_handlers = calloc(NSIG, sizeof(struct sigaction));
+
         // Install our handler
         [self setupHandlers];
     }
     return self;
 }
 
+- (void)dealloc {
+    free(_prev_signal_handlers);
+}
+
 - (void)setupHandlers {
+    _defaultExceptionHandler = NSGetUncaughtExceptionHandler();
     NSSetUncaughtExceptionHandler(&MPHandleException);
-    signal(SIGABRT, MPSignalHandler);
-    signal(SIGILL, MPSignalHandler);
-    signal(SIGSEGV, MPSignalHandler);
-    signal(SIGFPE, MPSignalHandler);
-    signal(SIGBUS, MPSignalHandler);
-    signal(SIGPIPE, MPSignalHandler);
+
+    struct sigaction action;
+    sigemptyset(&action.sa_mask);
+    action.sa_flags = SA_SIGINFO;
+    action.sa_sigaction = &MPSignalHandler;
+    int signals[] = {SIGABRT, SIGILL, SIGSEGV, SIGFPE, SIGBUS, SIGPIPE};
+    for (int i = 0; i < sizeof(signals) / sizeof(int); i++) {
+        struct sigaction prev_action;
+        int err = sigaction(signals[i], &action, &prev_action);
+        if (err == 0) {
+            memcpy(_prev_signal_handlers + signals[i], &prev_action, sizeof(prev_action));
+        } else {
+            NSLog(@"Errored while trying to set up sigaction for signal %d", signals[i]);
+        }
+    }
 }
 
 - (void)addMixpanelInstance:(Mixpanel *)instance {
@@ -93,88 +108,66 @@ const NSInteger UncaughtExceptionHandlerReportAddressCount = 5;
     [self.mixpanelInstances addObject:instance];
 }
 
-void MPSignalHandler(int signal)
-{
-    int32_t exceptionCount = OSAtomicIncrement32(&UncaughtExceptionCount);
-    if (exceptionCount > UncaughtExceptionMaximum)
-    {
-        return;
-    }
-
-    NSMutableDictionary *userInfo =
-    [NSMutableDictionary
-     dictionaryWithObject:[NSNumber numberWithInt:signal]
-     forKey:UncaughtExceptionHandlerSignalKey];
-
-    NSArray *callStack = [MixpanelExceptionHandler backtrace];
-    [userInfo
-     setObject:callStack
-     forKey:UncaughtExceptionHandlerAddressesKey];
-
-    [MixpanelExceptionHandler performSelectorOnMainThread:@selector(mp_handleUncaughtException:)
-                              withObject:[NSException
-                                          exceptionWithName:UncaughtExceptionHandlerSignalExceptionName
-                                          reason:
-                                          [NSString stringWithFormat:
-                                           NSLocalizedString(@"Signal %d was raised.", nil),
-                                           signal]
-                                          userInfo:
-                                          [NSDictionary
-                                           dictionaryWithObject:[NSNumber numberWithInt:signal]
-                                           forKey:UncaughtExceptionHandlerSignalKey]] waitUntilDone:YES];
-}
-
-void MPHandleException(NSException *exception)
-{
-    int32_t exceptionCount = OSAtomicIncrement32(&UncaughtExceptionCount);
-    if (exceptionCount > UncaughtExceptionMaximum)
-    {
-        return;
-    }
-
-    NSArray *callStack = [MixpanelExceptionHandler backtrace];
-    NSMutableDictionary *userInfo =
-    [NSMutableDictionary dictionaryWithDictionary:[exception userInfo]];
-    [userInfo
-     setObject:callStack
-     forKey:UncaughtExceptionHandlerAddressesKey];
-
-    [MixpanelExceptionHandler performSelectorOnMainThread:@selector(mp_handleUncaughtException:)
-                              withObject:[NSException
-                                          exceptionWithName:[exception name]
-                                          reason:[exception reason]
-                                          userInfo:userInfo] waitUntilDone:YES];
-}
-
-
-+ (void) mp_handleUncaughtException:(NSException *)exception {
+void MPSignalHandler(int signal, struct __siginfo *info, void *context) {
     MixpanelExceptionHandler *handler = [MixpanelExceptionHandler sharedHandler];
 
+    int32_t exceptionCount = OSAtomicIncrement32(&UncaughtExceptionCount);
+    if (exceptionCount <= UncaughtExceptionMaximum) {
+        NSArray *callStack = [MixpanelExceptionHandler backtrace];
+        NSDictionary *userInfo = @{UncaughtExceptionHandlerSignalKey: @(signal),
+                                   UncaughtExceptionHandlerAddressesKey: callStack};
+        NSException *exception = [NSException exceptionWithName:UncaughtExceptionHandlerSignalExceptionName
+                                                         reason:[NSString stringWithFormat:@"Signal %d was raised.", signal]
+                                                       userInfo:userInfo];
+
+        [handler mp_handleUncaughtException:exception];
+    }
+
+    struct sigaction prev_action = handler.prev_signal_handlers[signal];
+    if (prev_action.sa_flags & SA_SIGINFO) {
+        if (prev_action.sa_sigaction) {
+            prev_action.sa_sigaction(signal, info, context);
+        }
+    } else if (prev_action.sa_handler) {
+        prev_action.sa_handler(signal);
+    }
+}
+
+void MPHandleException(NSException *exception) {
+    MixpanelExceptionHandler *handler = [MixpanelExceptionHandler sharedHandler];
+
+    int32_t exceptionCount = OSAtomicIncrement32(&UncaughtExceptionCount);
+    if (exceptionCount <= UncaughtExceptionMaximum) {
+        NSArray *callStack = [MixpanelExceptionHandler backtrace];
+        NSMutableDictionary *userInfo = [[exception userInfo] mutableCopy];
+        userInfo[UncaughtExceptionHandlerAddressesKey] = callStack;
+        NSException *exceptionWithCallstack = [NSException exceptionWithName:[exception name]
+                                                                      reason:[exception reason]
+                                                                    userInfo:userInfo];
+
+        [handler mp_handleUncaughtException:exceptionWithCallstack];
+    }
+
+    if (handler.defaultExceptionHandler) {
+        handler.defaultExceptionHandler(exception);
+    }
+}
+
+
+- (void) mp_handleUncaughtException:(NSException *)exception {
     // Archive the values for each Mixpanel instance
-    for (Mixpanel *instance in handler.mixpanelInstances) {
-        [instance archive];
+    for (Mixpanel *instance in self.mixpanelInstances) {
         NSMutableDictionary *properties = [[NSMutableDictionary alloc] init];
         [properties setValue:[exception reason] forKey:@"$ae_crashed_reason"];
         [instance track:@"$ae_crashed" properties:properties];
-        dispatch_sync(instance.serialQueue, ^{});
+        dispatch_sync(instance.serialQueue, ^{
+            [instance archive];
+        });
     }
-
-    NSSetUncaughtExceptionHandler(NULL);
-    signal(SIGABRT, SIG_DFL);
-    signal(SIGILL, SIG_DFL);
-    signal(SIGSEGV, SIG_DFL);
-    signal(SIGFPE, SIG_DFL);
-    signal(SIGBUS, SIG_DFL);
-    signal(SIGPIPE, SIG_DFL);
     NSLog(@"Encountered an uncaught exception. All Mixpanel instances were archived.");
-
     NSLog(@"%@", [NSString stringWithFormat:@"Debug details follow:\n%@\n%@",
                   [exception reason],
                   [[exception userInfo] objectForKey:UncaughtExceptionHandlerAddressesKey]]);
-    if (handler.defaultExceptionHandler) {
-        // Ensure the existing handler gets called once we're finished
-        handler.defaultExceptionHandler(exception);
-    }
 }
 
 


### PR DESCRIPTION
* changed to using `sigaction` instead of `signal` as it appears more standard, and handlers registered with `signal` will be returned with `sigaction` so we'll still call them, whereas the opposite may not be true
* no longer unregister signal and exception handling after getting one signal or exception
* calling on main thread seemed unnecessary so i got rid of that
* moved `archive` call after tracking automatic event, not before (it seemed to work regardless)

this should fix the issues with mixpanel blocking other crash reporting in https://github.com/mixpanel/mixpanel-iphone/issues/704