### PR TITLE
fix a crash in push notif handling

### DIFF
--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -466,8 +466,10 @@ static NSString *defaultProjectToken;
             self.hasAddedObserver = YES;
         }
 
+        BOOL selectorFromNewClass = NO;
         if (class_getInstanceMethod(newCls, NSSelectorFromString(@"userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:"))) {
             selector = NSSelectorFromString(@"userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:");
+            selectorFromNewClass = YES;
         } else if (class_getInstanceMethod(cls, NSSelectorFromString(@"application:didReceiveRemoteNotification:fetchCompletionHandler:"))) {
             selector = NSSelectorFromString(@"application:didReceiveRemoteNotification:fetchCompletionHandler:");
         } else if (class_getInstanceMethod(cls, NSSelectorFromString(@"application:didReceiveRemoteNotification:"))) {
@@ -475,7 +477,7 @@ static NSString *defaultProjectToken;
         }
 
         if (selector) {
-            if (newCls) {
+            if (selectorFromNewClass) {
                 [MPSwizzler swizzleSelector:selector
                                     onClass:newCls
                                   withBlock:^(id view, SEL command, UIApplication *application, UNNotificationResponse *response) {


### PR DESCRIPTION
crash was caused by swizzling with the wrong block when UNUserNotification has a delegate but it doesn't implement the method we're looking for

fixes https://github.com/mixpanel/mixpanel-iphone/issues/722