### PR TITLE
Removing targets should be always performed on the main thread

### DIFF
--- a/Mixpanel/MPUIControlBinding.m
+++ b/Mixpanel/MPUIControlBinding.m
@@ -177,7 +177,9 @@
         // remove target-action pairs
         for (UIControl *control in self.appliedTo.allObjects) {
             if (control && [control isKindOfClass:[UIControl class]]) {
-                [self stopOnView:control];
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    [self stopOnView:control];
+                });
             }
         }
         [self resetAppliedTo];


### PR DESCRIPTION
Fix for this issue: https://github.com/mixpanel/mixpanel-iphone/issues/732