### PR TITLE
Fix Dereference Crash Running in AddressSanitizer

### DIFF
--- a/Mixpanel/MPTweakInline.m
+++ b/Mixpanel/MPTweakInline.m
@@ -130,6 +130,9 @@ static MPTweak *_MPTweakCreateWithEntry(NSString *name, mp_tweak_entry *entry)
         size_t count = size / sizeof(mp_tweak_entry);
         for (size_t i = 0; i < count; i++) {
             mp_tweak_entry *entry = &data[i];
+            if (entry->name == nil) {
+                continue;
+            }
             NSString *name = [NSString stringWithString:*entry->name];
             if ([store tweakWithName:name] == nil) {
                 MPTweak *tweak = _MPTweakCreateWithEntry(name, entry);


### PR DESCRIPTION
The entry is full of nil objects when running in AddressSanitizer. Don't try to derefence a nil pointer.