### PR TITLE
Update Mixpanel.podspec

### DIFF
--- a/Mixpanel.podspec
+++ b/Mixpanel.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'Mixpanel'
-  s.version      = '3.2.4'
+  s.version      = '3.2.3'
   s.summary      = 'iPhone tracking library for Mixpanel Analytics'
   s.homepage     = 'https://mixpanel.com'
   s.license      = 'Apache License, Version 2.0'

--- a/Mixpanel.podspec
+++ b/Mixpanel.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'Mixpanel'
-  s.version      = '3.2.3'
+  s.version      = '3.2.4'
   s.summary      = 'iPhone tracking library for Mixpanel Analytics'
   s.homepage     = 'https://mixpanel.com'
   s.license      = 'Apache License, Version 2.0'
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.ios.public_header_files = 'Mixpanel/Mixpanel.h', 'Mixpanel/MixpanelPeople.h', 'Mixpanel/MPTweak.h', 'Mixpanel/MPTweakInline.h', 'Mixpanel/MPTweakInlineInternal.h', 'Mixpanel/MPTweakStore.h', 'Mixpanel/_MPTweakBindObserver.h'
   s.ios.private_header_files = 'Mixpanel/MixpanelPeoplePrivate.h', 'Mixpanel/MPNetworkPrivate.h', 'Mixpanel/MixpanelPrivate.h'
   s.ios.resources   = ['Mixpanel/**/*.{png,storyboard,xib}']
-  s.ios.frameworks = 'UIKit', 'Foundation', 'SystemConfiguration', 'CoreTelephony', 'Accelerate', 'CoreGraphics', 'QuartzCore'
+  s.ios.frameworks = 'UIKit', 'Foundation', 'SystemConfiguration', 'CoreTelephony', 'Accelerate', 'CoreGraphics', 'QuartzCore', 'StoreKit', 'UserNotifications'
   s.tvos.deployment_target = '9.0'
   s.tvos.source_files  = 'Mixpanel/Mixpanel.{m,h}', 'Mixpanel/MixpanelPrivate.h', 'Mixpanel/MixpanelPeople.{m,h}', 'Mixpanel/MixpanelPeoplePrivate.h', 'Mixpanel/MPNetwork.{m,h}', 'Mixpanel/MPNetworkPrivate.h', 'Mixpanel/MPLogger.h', 'Mixpanel/MPFoundation.h', 'Mixpanel/MixpanelExceptionHandler.{m,h}'
   s.tvos.public_header_files = 'Mixpanel/Mixpanel.h', 'Mixpanel/MixpanelPeople.h'


### PR DESCRIPTION
Reason: When integrating MixPanel 3.2.3 with Cocoapods, it fails, because the SDK refers iOS frameworks, that are not listed in the ios.frameworks section.

StoreKit referenced here: https://github.com/mixpanel/mixpanel-iphone/blob/master/Mixpanel/AutomaticEvents.h#L10
UserNotifications referenced here: https://github.com/mixpanel/mixpanel-iphone/blob/2b05839cbbdce7e87ab8d9ca8c0358cb90427e64/Mixpanel/Mixpanel.m#L17

Resolves: https://github.com/mixpanel/mixpanel-iphone/issues/728