### PR TITLE
remove global variables in MixpanelExceptionHandler

### DIFF
--- a/Mixpanel/MixpanelExceptionHandler.m
+++ b/Mixpanel/MixpanelExceptionHandler.m
@@ -13,15 +13,11 @@
 #include <libkern/OSAtomic.h>
 #include <execinfo.h>
 
-NSString * const UncaughtExceptionHandlerSignalExceptionName = @"UncaughtExceptionHandlerSignalExceptionName";
-NSString * const UncaughtExceptionHandlerSignalKey = @"UncaughtExceptionHandlerSignalKey";
-NSString * const UncaughtExceptionHandlerAddressesKey = @"UncaughtExceptionHandlerAddressesKey";
+static NSString * const UncaughtExceptionHandlerSignalExceptionName = @"UncaughtExceptionHandlerSignalExceptionName";
+static NSString * const UncaughtExceptionHandlerSignalKey = @"UncaughtExceptionHandlerSignalKey";
 
-volatile int32_t UncaughtExceptionCount = 0;
-const int32_t UncaughtExceptionMaximum = 10;
-
-const NSInteger UncaughtExceptionHandlerSkipAddressCount = 4;
-const NSInteger UncaughtExceptionHandlerReportAddressCount = 5;
+static volatile int32_t UncaughtExceptionCount = 0;
+static const int32_t UncaughtExceptionMaximum = 10;
 
 @interface MixpanelExceptionHandler ()
 


### PR DESCRIPTION
should fix https://github.com/mixpanel/mixpanel-iphone/issues/750 and https://github.com/mixpanel/mixpanel-iphone/issues/744