### PR TITLE
only attempt to convert and add push token if present

### DIFF
--- a/Mixpanel/MixpanelPeople.m
+++ b/Mixpanel/MixpanelPeople.m
@@ -150,8 +150,9 @@
 
 - (void)addPushDeviceToken:(NSData *)deviceToken
 {
-    if (deviceToken){
-        NSDictionary *properties = @{@"$ios_devices": @[[MixpanelPeople pushDeviceTokenToString:deviceToken]]};
+    NSString *tokenString = [MixpanelPeople pushDeviceTokenToString:deviceToken]
+    if(tokenString){
+        NSDictionary *properties = @{@"$ios_devices": @[tokenString]};
         [self addPeopleRecordToQueueWithAction:@"$union" andProperties:properties];
     }
 }

--- a/Mixpanel/MixpanelPeople.m
+++ b/Mixpanel/MixpanelPeople.m
@@ -150,8 +150,10 @@
 
 - (void)addPushDeviceToken:(NSData *)deviceToken
 {
-    NSDictionary *properties = @{@"$ios_devices": @[[MixpanelPeople pushDeviceTokenToString:deviceToken]]};
-    [self addPeopleRecordToQueueWithAction:@"$union" andProperties:properties];
+    if (deviceToken){
+        NSDictionary *properties = @{@"$ios_devices": @[[MixpanelPeople pushDeviceTokenToString:deviceToken]]};
+        [self addPeopleRecordToQueueWithAction:@"$union" andProperties:properties];
+    }
 }
 
 - (void)removeAllPushDeviceTokens


### PR DESCRIPTION
cc: @amitayfeder1

Right now `addPushDeviceToken` blindly attempts to call `pushDeviceTokenToString` which returns `nil` if deviceToken isn't present. Passing `nil` to NSDictionary causes a crash. This change checks if there's actually a push token before attempting to convert to a string. 

We used to handle this scenario in 2.9.9 via the logic here: https://github.com/mixpanel/mixpanel-iphone/blob/v2.9.9/Mixpanel/Mixpanel.m#L2093-L2095