### PR TITLE
allow users to disable auto push tracking

### DIFF
--- a/Mixpanel/Mixpanel.h
+++ b/Mixpanel/Mixpanel.h
@@ -173,6 +173,13 @@ NS_ASSUME_NONNULL_BEGIN
 @property (atomic) BOOL enableLogging;
 
 /*!
+ Controls whether to disable automatic tracking of push notifications.
+ 
+ Defaults to YES.
+ */
+@property (atomic) BOOL enableAutomaticPushTracking;
+
+/*!
  Determines the time, in seconds, that a mini notification will remain on
  the screen before automatically hiding itself.
 

--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -117,6 +117,7 @@ static NSString *defaultProjectToken;
         self.showNotificationOnActive = YES;
         self.checkForNotificationsOnActive = YES;
         self.checkForVariantsOnActive = YES;
+        self.enableAutomaticPushTracking = YES;
         self.miniNotificationPresentationTime = 6.0;
 
         self.distinctId = [self defaultDistinctId];
@@ -155,7 +156,9 @@ static NSString *defaultProjectToken;
 #if !MIXPANEL_NO_NOTIFICATION_AB_TEST_SUPPORT
             [self executeCachedVariants];
             [self executeCachedEventBindings];
-            [self setupAutomaticPushTracking];
+            if (enableAutomaticPushTracking) {
+                [self setupAutomaticPushTracking];
+            }
             NSDictionary *remoteNotification = launchOptions[UIApplicationLaunchOptionsRemoteNotificationKey];
             if (remoteNotification) {
                 [self trackPushNotification:remoteNotification event:@"$app_open"];


### PR DESCRIPTION
cc @amitayfeder1

Users don't have a way to disable automatic push tracking. This PR provides a boolean `enableAutomaticPushTracking` that allows users to optionally disable `setupAutomaticPushTracking`.