### PR TITLE
fix typo with macro.

### DIFF
--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -1993,7 +1993,7 @@ static void MixpanelReachabilityCallback(SCNetworkReachabilityRef target, SCNetw
         [shownVariants addEntriesFromDictionary:shownVariant];
         [superProperties addEntriesFromDictionary:@{@"$experiments": [shownVariants copy]}];
         self.superProperties = [superProperties copy];
-#if !MIXPANEL_NO_UI_APPLICATION_ACCESS
+#if !MIXPANEL_NO_UIAPPLICATION_ACCESS
         if (![Mixpanel isAppExtension]) {
             dispatch_async(dispatch_get_main_queue(), ^{
                 if ([Mixpanel sharedUIApplication].applicationState == UIApplicationStateBackground) {


### PR DESCRIPTION
i'm pretty sure there's no real issue here, since it shouldn't be doing ab tests for app extensions anyway

addresses https://github.com/mixpanel/mixpanel-iphone/issues/759