### PR TITLE
Concurrency improvements

### DIFF
--- a/Mixpanel/Mixpanel.h
+++ b/Mixpanel/Mixpanel.h
@@ -522,7 +522,7 @@ extern NSString *const MPNotificationTypeTakeover;
 /*!
  Clears all stored properties and distinct IDs. Useful if your app's user logs out.
  */
-- (void)reset;
+- (void)resetWithCompletion:(void (^)(void))handler;
 
 /*!
  Uploads queued data to the Mixpanel server.

--- a/Mixpanel/Mixpanel.h
+++ b/Mixpanel/Mixpanel.h
@@ -65,6 +65,13 @@ extern NSString *const MPNotificationTypeTakeover;
 @property (atomic, readonly, strong) MixpanelPeople *people;
 
 /*!
+ The distinct ID of the current user that can be called from any queue.
+
+ See the documentation for distinctId below for more information.
+ */
+- (NSString *)safeDistinctId;
+
+/*!
  The distinct ID of the current user.
 
  A distinct ID is a string that uniquely identifies one of your users. By default, 

--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -244,6 +244,16 @@ static NSString *defaultProjectToken;
 }
 #endif
 
+- (NSString *)safeDistinctId {
+    __block NSString *result;
+
+    dispatch_sync(self.serialQueue, ^{
+        result = self.distinctId;
+    });
+
+    return result;
+}
+
 #if !MIXPANEL_NO_AUTOMATIC_EVENTS_SUPPORT
 - (void)setValidationEnabled:(BOOL)validationEnabled {
     _validationEnabled = validationEnabled;

--- a/Mixpanel/MixpanelPeople.m
+++ b/Mixpanel/MixpanelPeople.m
@@ -80,7 +80,7 @@
         properties = [properties copy];
         BOOL ignore_time = self.ignoreTime;
 
-        dispatch_async(strongMixpanel.serialQueue, ^{
+        dispatch_sync(strongMixpanel.serialQueue, ^{
             NSMutableDictionary *r = [NSMutableDictionary dictionary];
             NSMutableDictionary *p = [NSMutableDictionary dictionary];
             r[@"$token"] = strongMixpanel.apiToken;

--- a/Mixpanel/MixpanelPrivate.h
+++ b/Mixpanel/MixpanelPrivate.h
@@ -98,6 +98,7 @@
 @property (nonatomic, strong) NSMutableArray *peopleQueue;
 @property (nonatomic) dispatch_queue_t serialQueue;
 @property (nonatomic) dispatch_queue_t networkQueue;
+@property (nonatomic) dispatch_queue_t backgroundQueue;
 @property (nonatomic, strong) NSMutableDictionary *timedEvents;
 @property (nonatomic, strong) SessionMetadata *sessionMetadata;
 


### PR DESCRIPTION
### My issue

I ran into what I think may be a bug in the Mixpanel SDK. This is how I reproduce it:

1. Sign into app with an existing account.
2. The sign in changes the Mixpanel distinct ID.
3. Because I changed the distinct ID I notify our code that controls Branch SDK because per Branch documentation anytime Mixpanel distinct ID changes Branch SDK should be updated.
4. When the code that controls Branch SDK is notified it gets the current distinct ID from Mixpanel.
5. The distinct ID does not match the distinct ID of the new signed in user. Instead it is the previous distinct ID that Mixpanel SDK stored which is a problem.

### What I think the root cause is

Looking at the Mixpanel SDK code it looks like a concurrency issue. When I call `identify` the function does `dispatch_async(self.serialQueue, ^{` to add thread safety to stuff like `self.distinctId = distinctId;`. Because `dispatch_async` is used and not `dispatch_sync`, the `distinctId` will not get updated during the current run loop. This explains why my code that controls Branch SDK does not get the distinct ID for the new signed in user.

### A solution

I think this could be fixed by using `dispatch_sync` instead of `dispatch_async` when accessing data like `distinctId`. And then a `dispatch_sync` can be added to public `distinctId` accessor to truly make it thread safe. Right now I don't think read access to distinctId is completely safe because it doesn't use any dispatch. Is there a specific reason why `dispatch_async` is used? It seems like the dispatch is just for safety and there isn't long running work being done so `dispatch_sync` should be fine.

Also use of `@synchronized` seems redundant and I think could be removed and just rely on GCD.

Because replacing `dispatch_async` with `dispatch_sync` can change the order that code gets executed somebody that is familiar with this code would probably need to make sure there are no order of execution issues.