### PR TITLE
Enlarge the dismiss button for in-app notification

### DIFF
--- a/Mixpanel/MPTakeoverNotificationViewController~ipad.xib
+++ b/Mixpanel/MPTakeoverNotificationViewController~ipad.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="16E144f" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="ipad9_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -81,13 +81,13 @@
                             </constraints>
                         </view>
                         <button opaque="NO" contentMode="center" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pOh-07-cCm" userLabel="Button - Close">
-                            <rect key="frame" x="224" y="20" width="30" height="30"/>
+                            <rect key="frame" x="210" y="20" width="44" height="44"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="23" id="BNF-qy-r5Z">
-                                    <variation key="heightClass=regular-widthClass=regular" constant="30"/>
+                                    <variation key="heightClass=regular-widthClass=regular" constant="44"/>
                                 </constraint>
                                 <constraint firstAttribute="width" constant="23" id="TdL-4E-5SU">
-                                    <variation key="heightClass=regular-widthClass=regular" constant="30"/>
+                                    <variation key="heightClass=regular-widthClass=regular" constant="44"/>
                                 </constraint>
                             </constraints>
                             <fontDescription key="fontDescription" type="system" pointSize="13"/>

--- a/Mixpanel/MPTakeoverNotificationViewController~iphonelandscape.xib
+++ b/Mixpanel/MPTakeoverNotificationViewController~iphonelandscape.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="16E144f" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="landscape">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -178,10 +178,10 @@
                     </constraints>
                 </view>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dCO-y0-0yf" userLabel="Button - Close">
-                    <rect key="frame" x="629" y="15" width="23" height="23"/>
+                    <rect key="frame" x="608" y="15" width="44" height="44"/>
                     <constraints>
-                        <constraint firstAttribute="width" constant="23" id="DkE-Ho-6vd"/>
-                        <constraint firstAttribute="height" constant="23" id="Qk1-gQ-kdI"/>
+                        <constraint firstAttribute="width" constant="44" id="DkE-Ho-6vd"/>
+                        <constraint firstAttribute="height" constant="44" id="Qk1-gQ-kdI"/>
                     </constraints>
                     <fontDescription key="fontDescription" type="system" pointSize="13"/>
                     <inset key="contentEdgeInsets" minX="10" minY="0.0" maxX="0.0" maxY="10"/>

--- a/Mixpanel/MPTakeoverNotificationViewController~iphoneportrait.xib
+++ b/Mixpanel/MPTakeoverNotificationViewController~iphoneportrait.xib
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="16E144f" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina5_5" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
-        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -162,10 +162,10 @@
                     </constraints>
                 </view>
                 <button opaque="NO" contentMode="topRight" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6kd-pr-ub6" userLabel="Button - Close">
-                    <rect key="frame" x="339" y="38" width="16" height="16"/>
+                    <rect key="frame" x="350" y="50" width="44" height="44"/>
                     <constraints>
-                        <constraint firstAttribute="width" constant="16" id="AZI-CZ-rjG"/>
-                        <constraint firstAttribute="height" constant="16" id="Jx8-YG-Qxi"/>
+                        <constraint firstAttribute="width" constant="44" id="AZI-CZ-rjG"/>
+                        <constraint firstAttribute="height" constant="44" id="Jx8-YG-Qxi"/>
                     </constraints>
                     <fontDescription key="fontDescription" type="system" pointSize="13"/>
                     <state key="normal" image="MPCloseButton.png">


### PR DESCRIPTION
This PR is to address the issue 
https://github.com/mixpanel/mixpanel-iphone/issues/774
"Button to dismiss fullscreen in-app message is too tiny, hard to tap"
