### PR TITLE
Fix the issue that applicationDidEnterBackground is blocking the main…

### DIFF
--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -1514,9 +1514,9 @@ static void MixpanelReachabilityCallback(SCNetworkReachabilityRef target, SCNetw
     if (self.flushOnBackground) {
         [self flush];
     } else {
-        [self dispatchOnNetworkQueue:^{
+        dispatch_async(self.serialQueue, ^{
             [self archive];
-        }];
+        });
     }
 #endif
 }
@@ -1524,9 +1524,9 @@ static void MixpanelReachabilityCallback(SCNetworkReachabilityRef target, SCNetw
 - (void)applicationWillTerminate:(NSNotification *)notification
 {
     MPLogInfo(@"%@ application will terminate", self);
-    [self dispatchOnNetworkQueue:^{
+    dispatch_async(self.serialQueue, ^{
         [self archive];
-    }];
+    });
 }
 
 #if !defined(MIXPANEL_MACOS)
@@ -1574,9 +1574,9 @@ static void MixpanelReachabilityCallback(SCNetworkReachabilityRef target, SCNetw
         }];
     } else {
         // only need to archive if don't flush because flush archives at the end
-        [self dispatchOnNetworkQueue:^{
+        dispatch_async(self.serialQueue, ^{
             [self archive];
-        }];
+        });
     }
 
     dispatch_group_notify(bgGroup, dispatch_get_main_queue(), ^{


### PR DESCRIPTION
Fix the issue that applicationDidEnterBackground is blocking the main thread with @synchronized(self) inside `archive`, result in crash triggered by watchdog.

https://github.com/mixpanel/mixpanel-iphone/issues/776
@synchronized does not need to be inside `archive`, because in Mixpanel internally `archive` itself is always being called inside a serial queue.
Fix anywhere if `archive` not being called in a background thread.