### PR TITLE
hide keyboard while showing inapp-message

### DIFF
--- a/Mixpanel/MPNotificationViewController.m
+++ b/Mixpanel/MPNotificationViewController.m
@@ -178,6 +178,7 @@
     self.window.alpha = 0;
     self.window.windowLevel = UIWindowLevelAlert;
     self.window.rootViewController = self;
+    [[[Mixpanel sharedUIApplication] keyWindow] endEditing:YES];
     [self.window setHidden:NO];
 
     [UIView animateWithDuration:0.25 animations:^{


### PR DESCRIPTION
When a takeover notification received while using the keyboard, keyboard stays on the window like the image below and doesn't disappear until to close the notification.

![whatsapp image 2018-07-26 at 13 23 21](https://user-images.githubusercontent.com/20573437/43256998-275496dc-90d7-11e8-8748-4661de39a22f.jpeg)
