### PR TITLE
Add new watch architecture

### DIFF
--- a/Mixpanel.xcodeproj/project.pbxproj
+++ b/Mixpanel.xcodeproj/project.pbxproj
@@ -822,7 +822,6 @@
 				E1ECD0191FA3AF40002104E8 /* SessionMetadata.m */,
 				F0ACBDEA1F8C46B400ABF03D /* MPConnectIntegrations.h */,
 				F0ACBDEB1F8C46B400ABF03D /* MPConnectIntegrations.m */,
-
 			);
 			name = Source;
 			path = Mixpanel;
@@ -1315,7 +1314,7 @@
 				SUPPORTED_PLATFORMS = "watchsimulator watchos";
 				TARGETED_DEVICE_FAMILY = 4;
 				VALID_ARCHS = "armv7k i386 arm64_32";
-				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+				WATCHOS_DEPLOYMENT_TARGET = 3.0;
 			};
 			name = Debug;
 		};
@@ -1347,7 +1346,7 @@
 				SUPPORTED_PLATFORMS = "watchsimulator watchos";
 				TARGETED_DEVICE_FAMILY = 4;
 				VALID_ARCHS = "armv7k i386 arm64_32";
-				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+				WATCHOS_DEPLOYMENT_TARGET = 3.0;
 			};
 			name = Release;
 		};

--- a/Mixpanel.xcodeproj/project.pbxproj
+++ b/Mixpanel.xcodeproj/project.pbxproj
@@ -1314,7 +1314,7 @@
 				SDKROOT = watchos;
 				SUPPORTED_PLATFORMS = "watchsimulator watchos";
 				TARGETED_DEVICE_FAMILY = 4;
-				VALID_ARCHS = "armv7k i386";
+				VALID_ARCHS = "armv7k i386 arm64_32";
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Debug;
@@ -1346,7 +1346,7 @@
 				SDKROOT = watchos;
 				SUPPORTED_PLATFORMS = "watchsimulator watchos";
 				TARGETED_DEVICE_FAMILY = 4;
-				VALID_ARCHS = "armv7k i386";
+				VALID_ARCHS = "armv7k i386 arm64_32";
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Release;


### PR DESCRIPTION
The series 4 Apple Watch announced today uses a new architecture.

Also, the deployment target for watchOS must be increased to 3.0, otherwise uploads to the App Store will result in the following: 

> ERROR ITMS-90081: "This bundle is invalid. Applications built for more than one architecture require an iOS Deployment Target of 3.0 or later."