### PR TITLE
Can not track UITextField UIControlEventEditingDidEnd event on iOS12. #800

### DIFF
--- a/Mixpanel/MPUIControlBinding.m
+++ b/Mixpanel/MPUIControlBinding.m
@@ -77,6 +77,12 @@
         [self setSwizzleClass:[UIControl class]];
         _controlEvent = controlEvent;
 
+        //iOS UITextField didMoveToWindow wont call its super method.So patch it.
+        if ([[[UIDevice currentDevice]systemVersion]floatValue]>=12.0f
+            && controlEvent == UIControlEventEditingDidEnd) {
+            [self setSwizzleClass:[UITextField class]];
+        }
+        
         if (verifyEvent == 0) {
             if (controlEvent & UIControlEventAllTouchEvents) {
                 verifyEvent = UIControlEventTouchDown;


### PR DESCRIPTION
Change-Id: Ic23431e7afae65e15c4faf70d40ea6924af66db6

See this issue.

[mixpanel-iphone/issues#800](https://github.com/mixpanel/mixpanel-iphone/issues/800)