### PR TITLE
Fixes for compile error when set preprocessor macro `MIXPANEL_NO_NOTI…

### DIFF
--- a/Mixpanel/AutomaticEvents.h
+++ b/Mixpanel/AutomaticEvents.h
@@ -7,14 +7,14 @@
 //
 
 #import <UIKit/UIKit.h>
-#import <StoreKit/StoreKit.h>
 #import "MixpanelPeople.h"
+
 
 @protocol TrackDelegate <NSObject>
 - (void)track:(NSString *)event properties:(NSDictionary *)properties;
 @end
 
-@interface AutomaticEvents: NSObject <SKPaymentTransactionObserver, SKProductsRequestDelegate>
+@interface AutomaticEvents: NSObject
 @property (atomic, weak) id<TrackDelegate> delegate;
 @property (atomic, assign) UInt64 minimumSessionDuration;
 @property (atomic, assign) UInt64 maximumSessionDuration;

--- a/Mixpanel/AutomaticEvents.m
+++ b/Mixpanel/AutomaticEvents.m
@@ -9,6 +9,11 @@
 #import "AutomaticEvents.h"
 #import "MPSwizzler.h"
 #import <objc/runtime.h>
+#import <StoreKit/StoreKit.h>
+
+@interface AutomaticEvents() <SKPaymentTransactionObserver, SKProductsRequestDelegate>
+
+@end
 
 @implementation AutomaticEvents {
     NSMutableDictionary *awaitingTransactions;

--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -13,8 +13,8 @@
 #import "MPLogger.h"
 #import "MPNetworkPrivate.h"
 
-#if !MIXPANEL_NO_NOTIFICATION_AB_TEST_SUPPORT
 #import <UserNotifications/UserNotifications.h>
+#if !MIXPANEL_NO_NOTIFICATION_AB_TEST_SUPPORT
 #import "NSThread+MPHelpers.h"
 #endif
 #if defined(MIXPANEL_WATCHOS)
@@ -1729,6 +1729,7 @@ static void MixpanelReachabilityCallback(SCNetworkReachabilityRef target, SCNetw
                     return;
                 }
 
+#if !MIXPANEL_NO_AUTOMATIC_EVENTS_SUPPORT
                 NSDictionary *config = object[@"config"];
                 if (config && [config isKindOfClass:NSDictionary.class]) {
                     NSDictionary *validationConfig = config[@"ce"];
@@ -1743,6 +1744,7 @@ static void MixpanelReachabilityCallback(SCNetworkReachabilityRef target, SCNetw
                         }
                     }
                 }
+#endif
 
                 id rawNotifications = object[@"notifications"];
                 NSMutableArray *parsedNotifications = [NSMutableArray array];

--- a/Mixpanel/MixpanelPrivate.h
+++ b/Mixpanel/MixpanelPrivate.h
@@ -48,11 +48,16 @@
 #import "MPConnectIntegrations.h"
 #endif
 
-#if !MIXPANEL_NO_NOTIFICATION_AB_TEST_SUPPORT
-@interface Mixpanel () <MPNotificationViewControllerDelegate, TrackDelegate>
-#else
+#if defined(MIXPANEL_NO_NOTIFICATION_AB_TEST_SUPPORT) && defined(MIXPANEL_NO_AUTOMATIC_EVENTS_SUPPORT)
 @interface Mixpanel ()
+#elif defined(MIXPANEL_NO_NOTIFICATION_AB_TEST_SUPPORT)
+@interface Mixpanel () <TrackDelegate>
+#elif defined(MIXPANEL_NO_AUTOMATIC_EVENTS_SUPPORT)
+@interface Mixpanel () <MPNotificationViewControllerDelegate>
+#else
+@interface Mixpanel () <MPNotificationViewControllerDelegate, TrackDelegate>
 #endif
+
 {
     NSUInteger _flushInterval;
     BOOL _enableVisualABTestAndCodeless;


### PR DESCRIPTION
Fixes for compile error when set preprocessor macro `MIXPANEL_NO_NOTIFICATION_AB_TEST_SUPPORT` and `MIXPANEL_NO_AUTOMATIC_EVENTS_SUPPORT`