### PR TITLE
Add support for display triggers in InApp notifications

### DIFF
--- a/HelloMixpanel/HelloMixpanel.xcodeproj/project.pbxproj
+++ b/HelloMixpanel/HelloMixpanel.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		0552DEFE1843DF00009AC90A /* HelloMixpanel.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0552DEFD1843DF00009AC90A /* HelloMixpanel.storyboard */; };
 		0563B603194A186300B40489 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2808F9911610EFE3005772B7 /* UIKit.framework */; };
 		0563B606194A189200B40489 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 05C13E5118184DBE00848D48 /* CFNetwork.framework */; };
+		057BE5C22239A4AE00071E94 /* SelectorEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 057BE5BF2239A13E00071E94 /* SelectorEvaluatorTests.swift */; };
 		05E98DF1191AE10000AFF3E1 /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 05E98DF0191AE10000AFF3E1 /* MapKit.framework */; };
 		05E98DF3191AE27200AFF3E1 /* test_variant.json in Resources */ = {isa = PBXBuildFile; fileRef = 05E98DF2191AE27200AFF3E1 /* test_variant.json */; };
 		05FF819E18452EA20073FBAC /* HomeViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 05FF819D18452EA20073FBAC /* HomeViewController.m */; };
@@ -329,6 +330,8 @@
 		05509E50196E47EE007E5C06 /* test_decide_response.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = test_decide_response.json; sourceTree = "<group>"; };
 		0552DEFD1843DF00009AC90A /* HelloMixpanel.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = HelloMixpanel.storyboard; sourceTree = "<group>"; };
 		055FA714194A6B020080A709 /* ABTestingTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ABTestingTests.m; sourceTree = "<group>"; };
+		057BE5BE2239A13E00071E94 /* HelloMixpanel-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "HelloMixpanel-Bridging-Header.h"; sourceTree = "<group>"; };
+		057BE5BF2239A13E00071E94 /* SelectorEvaluatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectorEvaluatorTests.swift; sourceTree = "<group>"; };
 		05C13E5118184DBE00848D48 /* CFNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = System/Library/Frameworks/CFNetwork.framework; sourceTree = SDKROOT; };
 		05C13E5318184DC700848D48 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		05E98DF0191AE10000AFF3E1 /* MapKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MapKit.framework; path = System/Library/Frameworks/MapKit.framework; sourceTree = SDKROOT; };
@@ -560,6 +563,7 @@
 				8673E0F319C3B7090099AB66 /* MPTimingViewController.h */,
 				8673E0F419C3B7090099AB66 /* MPTimingViewController.m */,
 				2808F9981610EFE3005772B7 /* Supporting Files */,
+				057BE5BE2239A13E00071E94 /* HelloMixpanel-Bridging-Header.h */,
 			);
 			path = HelloMixpanel;
 			sourceTree = "<group>";
@@ -579,6 +583,7 @@
 		2808F9B81610EFE4005772B7 /* HelloMixpanelTests */ = {
 			isa = PBXGroup;
 			children = (
+				057BE5BF2239A13E00071E94 /* SelectorEvaluatorTests.swift */,
 				055FA714194A6B020080A709 /* ABTestingTests.m */,
 				E18E6C3C1EAFC8CB00FDD3A2 /* AutomaticEventsTests.m */,
 				187939F919A2A7F400CC4FBE /* EventBindingTests.m */,
@@ -910,6 +915,7 @@
 				ORGANIZATIONNAME = Mixpanel;
 				TargetAttributes = {
 					2808F98C1610EFE3005772B7 = {
+						LastSwiftMigration = 1010;
 						SystemCapabilities = {
 							com.apple.Push = {
 								enabled = 1;
@@ -1163,6 +1169,7 @@
 			files = (
 				862FD908205B56FA007E28D1 /* MixpanelOptOutTests.m in Sources */,
 				51D96E811D120D3E001F622D /* MPNotificationTests.m in Sources */,
+				057BE5C22239A4AE00071E94 /* SelectorEvaluatorTests.swift in Sources */,
 				51D96E831D120D4F001F622D /* MixpanelPeopleTests.m in Sources */,
 				51D96E871D121763001F622D /* ABTestingTests.m in Sources */,
 				515EE7CC1D10D31A00D035A4 /* HelloMixpanelTests.m in Sources */,
@@ -1505,6 +1512,9 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloMixpanel/HelloMixpanel-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.2;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				WRAPPER_EXTENSION = app;
 			};
@@ -1543,6 +1553,8 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloMixpanel/HelloMixpanel-Bridging-Header.h";
+				SWIFT_VERSION = 4.2;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				WRAPPER_EXTENSION = app;
 			};
@@ -1552,7 +1564,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = DF79C3E955E4F278C2032E3E /* Pods-HelloMixpanelTests.debug.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/HelloMixpanel.app/HelloMixpanel";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
@@ -1599,7 +1610,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = BB2CF402A7CC0E97A5080D11 /* Pods-HelloMixpanelTests.release.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/HelloMixpanel.app/HelloMixpanel";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
@@ -1738,6 +1748,8 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloMixpanel/HelloMixpanel-Bridging-Header.h";
+				SWIFT_VERSION = 4.2;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				WRAPPER_EXTENSION = app;
 			};
@@ -1747,7 +1759,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E801B3EBBA1BC612E273C12C /* Pods-HelloMixpanelTests.appstore.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/HelloMixpanel.app/HelloMixpanel";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;

--- a/HelloMixpanel/HelloMixpanel.xcodeproj/project.pbxproj
+++ b/HelloMixpanel/HelloMixpanel.xcodeproj/project.pbxproj
@@ -800,7 +800,6 @@
 				2808F9AD1610EFE4005772B7 /* Frameworks */,
 				51D96E771D11EF69001F622D /* Copy Frameworks */,
 				11FBA527AAB4DE301A04BDD0 /* [CP] Embed Pods Frameworks */,
-				97D8318B565052717E5E5717 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -851,7 +850,6 @@
 				E12C04AE1D135F01007D2086 /* Copy Frameworks */,
 				E123C49C1D1354EC0015B425 /* Resources */,
 				768564EFBBB1CF00026F3472 /* [CP] Embed Pods Frameworks */,
-				6EDEBFE516C45FD65271D88E /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -1100,21 +1098,6 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		6EDEBFE516C45FD65271D88E /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-HelloMixpanel_tvOSTests/Pods-HelloMixpanel_tvOSTests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		768564EFBBB1CF00026F3472 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -1133,21 +1116,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-HelloMixpanel_tvOSTests/Pods-HelloMixpanel_tvOSTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		97D8318B565052717E5E5717 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-HelloMixpanelTests/Pods-HelloMixpanelTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		AD48B0E1D0FDE02B32D8F942 /* [CP] Check Pods Manifest.lock */ = {

--- a/HelloMixpanel/HelloMixpanel/HelloMixpanel-Bridging-Header.h
+++ b/HelloMixpanel/HelloMixpanel/HelloMixpanel-Bridging-Header.h
@@ -1,0 +1,5 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+#import "Mixpanel/Mixpanel-Swift.h"
+

--- a/HelloMixpanel/HelloMixpanelTests/MPNotificationTests.m
+++ b/HelloMixpanel/HelloMixpanelTests/MPNotificationTests.m
@@ -32,7 +32,7 @@
 }
 
 - (void)testParseTakeOverNotification {
-    NSData *takeOverNotificationData = [@"{\"id\": 1234, \"message_id\": 4444, \"title\": \"This is a title\", \"title_color\": 4294901760, \"body\": \"This is a body\", \"body_color\": 4294901760, \"image_url\": \"http://mixpanel.com/coolimage.png\", \"close_color\": 4294901760, \"type\": \"takeover\", \"bg_color\": 0, \"buttons\": [{\"bg_color\": 0, \"text\": \"Yes!\", \"border_color\": 4294901760, \"text_color\": 4294901760, \"cta_url\": \"mixpanel://deeplink/howareyou\"}],\"extras\": {\"image_fade\": true}}" dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *takeOverNotificationData = [@"{\"id\": 1234, \"message_id\": 4444, \"title\": \"This is a title\", \"title_color\": 4294901760, \"body\": \"This is a body\", \"body_color\": 4294901760, \"image_url\": \"http://mixpanel.com/coolimage.png\", \"close_color\": 4294901760, \"type\": \"takeover\", \"bg_color\": 0, \"buttons\": [{\"bg_color\": 0, \"text\": \"Yes!\", \"border_color\": 4294901760, \"text_color\": 4294901760, \"cta_url\": \"mixpanel://deeplink/howareyou\"}],\"extras\": {\"image_fade\": true}, \"display_triggers\": [{\"event\": \"test_event\"}]}" dataUsingEncoding:NSUTF8StringEncoding];
     NSDictionary *notifDict = [NSJSONSerialization JSONObjectWithData:takeOverNotificationData options:0 error:nil];
 
     XCTAssertNotNil([[MPTakeoverNotification alloc] initWithJSONObject:notifDict]);
@@ -142,10 +142,20 @@
     extraDict[@"image_fade"] = @"mixpanel";
     testDict[@"extras"] = extraDict;
     XCTAssertNil([[MPTakeoverNotification alloc] initWithJSONObject:testDict]);
+    
+    // valid - no display triggers
+    testDict = [NSMutableDictionary dictionaryWithDictionary:notifDict];
+    [testDict removeObjectForKey:@"display_triggers"];
+    XCTAssertNotNil([[MPTakeoverNotification alloc] initWithJSONObject:testDict]);
+    
+    // valid - with display triggers
+    testDict = [NSMutableDictionary dictionaryWithDictionary:notifDict];
+    MPTakeoverNotification *notif = [[MPTakeoverNotification alloc] initWithJSONObject:testDict];
+    XCTAssertTrue([notif hasDisplayTriggers]);
 }
 
 - (void)testMiniNotification {
-    NSData *miniNotificationData = [@"{\"id\": 1234, \"message_id\": 4444, \"body\": \"This is a body\", \"body_color\": 4294901760, \"image_tint_color\": 33283444, \"border_color\": 452243332, \"cta_url\": null, \"image_url\": \"https//mixpanel.com/image\", \"close_color\": 4294901760, \"type\": \"mini\", \"bg_color\": 0,\"extras\": {}}" dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *miniNotificationData = [@"{\"id\": 1234, \"message_id\": 4444, \"body\": \"This is a body\", \"body_color\": 4294901760, \"image_tint_color\": 33283444, \"border_color\": 452243332, \"cta_url\": null, \"image_url\": \"https//mixpanel.com/image\", \"close_color\": 4294901760, \"type\": \"mini\", \"bg_color\": 0,\"extras\": {}, \"display_triggers\": [{\"event\": \"test_event\"}]}" dataUsingEncoding:NSUTF8StringEncoding];
     NSDictionary *notifDict = [NSJSONSerialization JSONObjectWithData:miniNotificationData options:0 error:nil];
 
     XCTAssertNotNil([[MPMiniNotification alloc] initWithJSONObject:notifDict]);
@@ -166,6 +176,16 @@
     testDict = [NSMutableDictionary dictionaryWithDictionary:notifDict];
     testDict[@"border_color"] = @"#FFFFFFFF";
     XCTAssertNil([[MPMiniNotification alloc] initWithJSONObject:testDict]);
+    
+    // valid - no display triggers
+    testDict = [NSMutableDictionary dictionaryWithDictionary:notifDict];
+    [testDict removeObjectForKey:@"display_triggers"];
+    XCTAssertNotNil([[MPMiniNotification alloc] initWithJSONObject:testDict]);
+    
+    // valid - with display triggers
+    testDict = [NSMutableDictionary dictionaryWithDictionary:notifDict];
+    MPMiniNotification *notif = [[MPMiniNotification alloc] initWithJSONObject:testDict];
+    XCTAssertTrue([notif hasDisplayTriggers]);
 }
 
 - (void)testNoDoubleShowNotification {

--- a/HelloMixpanel/HelloMixpanelTests/MPNotificationTests.m
+++ b/HelloMixpanel/HelloMixpanelTests/MPNotificationTests.m
@@ -32,7 +32,7 @@
 }
 
 - (void)testParseTakeOverNotification {
-    NSData *takeOverNotificationData = [@"{\"id\": 1234, \"message_id\": 4444, \"title\": \"This is a title\", \"title_color\": 4294901760, \"body\": \"This is a body\", \"body_color\": 4294901760, \"image_url\": \"http://mixpanel.com/coolimage.png\", \"close_color\": 4294901760, \"type\": \"takeover\", \"bg_color\": 0, \"buttons\": [{\"bg_color\": 0, \"text\": \"Yes!\", \"border_color\": 4294901760, \"text_color\": 4294901760, \"cta_url\": \"mixpanel://deeplink/howareyou\"}],\"extras\": {\"image_fade\": true}, \"display_triggers\": [{\"event\": \"test_event\"}]}" dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *takeOverNotificationData = [@"{\"id\": 1234, \"message_id\": 4444, \"title\": \"This is a title\", \"title_color\": 4294901760, \"body\": \"This is a body\", \"body_color\": 4294901760, \"image_url\": \"http://mixpanel.com/coolimage.png\", \"close_color\": 4294901760, \"type\": \"takeover\", \"bg_color\": 0, \"buttons\": [{\"bg_color\": 0, \"text\": \"Yes!\", \"border_color\": 4294901760, \"text_color\": 4294901760, \"cta_url\": \"mixpanel://deeplink/howareyou\"}],\"extras\": {\"image_fade\": true}, \"display_triggers\": [{\"event\": \"test_event\", \"selector\":{\"operator\": \"defined\", \"children\": [{\"property\": \"event\", \"value\": \"prop1\"}]}}]}" dataUsingEncoding:NSUTF8StringEncoding];
     NSDictionary *notifDict = [NSJSONSerialization JSONObjectWithData:takeOverNotificationData options:0 error:nil];
 
     XCTAssertNotNil([[MPTakeoverNotification alloc] initWithJSONObject:notifDict]);
@@ -152,10 +152,12 @@
     testDict = [NSMutableDictionary dictionaryWithDictionary:notifDict];
     MPTakeoverNotification *notif = [[MPTakeoverNotification alloc] initWithJSONObject:testDict];
     XCTAssertTrue([notif hasDisplayTriggers]);
+    MPDisplayTrigger *trigger = [notif displayTriggers][0];
+    XCTAssertTrue([[trigger selector] count] > 0);
 }
 
 - (void)testMiniNotification {
-    NSData *miniNotificationData = [@"{\"id\": 1234, \"message_id\": 4444, \"body\": \"This is a body\", \"body_color\": 4294901760, \"image_tint_color\": 33283444, \"border_color\": 452243332, \"cta_url\": null, \"image_url\": \"https//mixpanel.com/image\", \"close_color\": 4294901760, \"type\": \"mini\", \"bg_color\": 0,\"extras\": {}, \"display_triggers\": [{\"event\": \"test_event\"}]}" dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *miniNotificationData = [@"{\"id\": 1234, \"message_id\": 4444, \"body\": \"This is a body\", \"body_color\": 4294901760, \"image_tint_color\": 33283444, \"border_color\": 452243332, \"cta_url\": null, \"image_url\": \"https//mixpanel.com/image\", \"close_color\": 4294901760, \"type\": \"mini\", \"bg_color\": 0,\"extras\": {}, \"display_triggers\": [{\"event\": \"test_event\", \"selector\":{\"operator\": \"==\", \"children\": [{\"property\": \"event\", \"value\": \"prop1\"}, {\"property\": \"literal\", \"value\": \"test_value\"}]}}]}" dataUsingEncoding:NSUTF8StringEncoding];
     NSDictionary *notifDict = [NSJSONSerialization JSONObjectWithData:miniNotificationData options:0 error:nil];
 
     XCTAssertNotNil([[MPMiniNotification alloc] initWithJSONObject:notifDict]);
@@ -186,6 +188,20 @@
     testDict = [NSMutableDictionary dictionaryWithDictionary:notifDict];
     MPMiniNotification *notif = [[MPMiniNotification alloc] initWithJSONObject:testDict];
     XCTAssertTrue([notif hasDisplayTriggers]);
+    
+    NSMutableDictionary *event = [[NSMutableDictionary alloc] init];
+    event[@"event"] = @"test_event_1";
+    XCTAssertFalse([notif matchesEvent:event]);
+    event[@"event"] = @"test_event";
+    XCTAssertFalse([notif matchesEvent:event]);
+    NSMutableDictionary *properties = [[NSMutableDictionary alloc] init];
+    properties[@"prop"] = @"test";
+    event[@"properties"] = properties;
+    XCTAssertFalse([notif matchesEvent:event]);
+    properties[@"prop1"] = @"blah";
+    XCTAssertFalse([notif matchesEvent:event]);
+    properties[@"prop1"] = @"test_value";
+    XCTAssertTrue([notif matchesEvent:event]);
 }
 
 - (void)testNoDoubleShowNotification {

--- a/HelloMixpanel/HelloMixpanelTests/SelectorEvaluatorTests.swift
+++ b/HelloMixpanel/HelloMixpanelTests/SelectorEvaluatorTests.swift
@@ -1,0 +1,409 @@
+//
+//  SelectorTests.swift
+//  MixpanelDemoTests
+//
+//  Created by Madhu Palani on 3/4/19.
+//  Copyright © 2019 Mixpanel. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import Mixpanel
+
+class SelectorEvaluatorTests: XCTestCase {
+    func testToNumber() {
+        XCTAssertNil(SelectorEvaluator.toNumber(value: nil))
+        XCTAssertNil(SelectorEvaluator.toNumber(value: Date(timeIntervalSince1970: 0)))
+        XCTAssertEqual(SelectorEvaluator.toNumber(value: true), 1)
+        XCTAssertEqual(SelectorEvaluator.toNumber(value: false), 0)
+        XCTAssertEqual(SelectorEvaluator.toNumber(value: Double(100.1)), 100.1)
+        XCTAssertEqual(SelectorEvaluator.toNumber(value: Int(101)), 101)
+        XCTAssertEqual(SelectorEvaluator.toNumber(value: NSNumber(value: 101.1)), 101.1)
+        XCTAssertEqual(SelectorEvaluator.toNumber(value: "100"), 100)
+        XCTAssertEqual(SelectorEvaluator.toNumber(value: "101.1"), 101.1)
+        XCTAssertEqual(SelectorEvaluator.toNumber(value: "abc"), 0)
+    }
+    
+    func testToBoolean() {
+        XCTAssertFalse(SelectorEvaluator.toBoolean(value: nil))
+        XCTAssertTrue(SelectorEvaluator.toBoolean(value: true))
+        XCTAssertFalse(SelectorEvaluator.toBoolean(value: false))
+        XCTAssertTrue(SelectorEvaluator.toBoolean(value: 100))
+        XCTAssertTrue(SelectorEvaluator.toBoolean(value: 0.1))
+        XCTAssertTrue(SelectorEvaluator.toBoolean(value: -1))
+        XCTAssertFalse(SelectorEvaluator.toBoolean(value: 0))
+        XCTAssertFalse(SelectorEvaluator.toBoolean(value: 0.0))
+        XCTAssertTrue(SelectorEvaluator.toBoolean(value: "abc"))
+        XCTAssertFalse(SelectorEvaluator.toBoolean(value: ""))
+        XCTAssertTrue(SelectorEvaluator.toBoolean(value: [1,2]))
+        XCTAssertFalse(SelectorEvaluator.toBoolean(value: []))
+        XCTAssertTrue(SelectorEvaluator.toBoolean(value: ["abc": 1]))
+        XCTAssertFalse(SelectorEvaluator.toBoolean(value: [:]))
+        XCTAssertTrue(SelectorEvaluator.toBoolean(value: Date(timeIntervalSince1970: 1)))
+        XCTAssertFalse(SelectorEvaluator.toBoolean(value: Date(timeIntervalSince1970: 0)))
+    }
+    
+    func testEvaluateNumber() {
+        XCTAssertNil(SelectorEvaluator.evaluateNumber(node: [:], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateNumber(node: ["operator": "or"], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateNumber(node: ["operator": "number"], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateNumber(node: ["operator": "number", "children": []], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateNumber(node: ["operator": "number", "children": [[], []]], properties: nil))
+        
+        XCTAssertEqual(SelectorEvaluator.evaluateNumber(node: ["operator": "number", "children": [["property": "event", "value": "prop"]]], properties: ["prop": Date(timeIntervalSince1970: 1)]), 1)
+        XCTAssertNil(SelectorEvaluator.evaluateNumber(node: ["operator": "number", "children": [["property": "event", "value": "prop"]]], properties: ["prop": [:]]))
+        XCTAssertNil(SelectorEvaluator.evaluateNumber(node: ["operator": "number", "children": [["property": "event", "value": "prop"]]], properties: ["prop": []]))
+        XCTAssertEqual(SelectorEvaluator.evaluateNumber(node: ["operator": "number", "children": [["property": "event", "value": "prop"]]], properties: ["prop": true]), 1)
+        XCTAssertEqual(SelectorEvaluator.evaluateNumber(node: ["operator": "number", "children": [["property": "event", "value": "prop"]]], properties: ["prop": false]), 0)
+        XCTAssertEqual(SelectorEvaluator.evaluateNumber(node: ["operator": "number", "children": [["property": "event", "value": "prop"]]], properties: ["prop": Double(100)]), 100)
+        XCTAssertEqual(SelectorEvaluator.evaluateNumber(node: ["operator": "number", "children": [["property": "event", "value": "prop"]]], properties: ["prop": Double(100.1)]), 100.1)
+        XCTAssertEqual(SelectorEvaluator.evaluateNumber(node: ["operator": "number", "children": [["property": "event", "value": "prop"]]], properties: ["prop": Int(101)]), 101)
+        XCTAssertEqual(SelectorEvaluator.evaluateNumber(node: ["operator": "number", "children": [["property": "event", "value": "prop"]]], properties: ["prop": "101"]), 101)
+        XCTAssertEqual(SelectorEvaluator.evaluateNumber(node: ["operator": "number", "children": [["property": "event", "value": "prop"]]], properties: ["prop": "10.1"]), 10.1)
+        XCTAssertEqual(SelectorEvaluator.evaluateNumber(node: ["operator": "number", "children": [["property": "event", "value": "prop"]]], properties: ["prop": "abc"]), 0)
+        XCTAssertEqual(SelectorEvaluator.evaluateNumber(node: ["operator": "number", "children": [["property": "event", "value": "prop"]]], properties: ["prop": ""]), 0)
+    }
+    
+    func testEvaluateBoolean() {
+        XCTAssertNil(SelectorEvaluator.evaluateBoolean(node: [:], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateBoolean(node: ["operator": "or"], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateBoolean(node: ["operator": "boolean"], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateBoolean(node: ["operator": "boolean", "children": []], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateBoolean(node: ["operator": "boolean", "children": [[], []]], properties: nil))
+        
+        XCTAssertFalse(SelectorEvaluator.evaluateBoolean(node: ["operator": "boolean", "children": [["property": "event", "value": "prop"]]], properties: [:])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateBoolean(node: ["operator": "boolean", "children": [["property": "event", "value": "prop"]]], properties: ["prop": true])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateBoolean(node: ["operator": "boolean", "children": [["property": "event", "value": "prop"]]], properties: ["prop": false])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateBoolean(node: ["operator": "boolean", "children": [["property": "event", "value": "prop"]]], properties: ["prop": 100])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateBoolean(node: ["operator": "boolean", "children": [["property": "event", "value": "prop"]]], properties: ["prop": 0])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateBoolean(node: ["operator": "boolean", "children": [["property": "event", "value": "prop"]]], properties: ["prop": "100"])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateBoolean(node: ["operator": "boolean", "children": [["property": "event", "value": "prop"]]], properties: ["prop": ""])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateBoolean(node: ["operator": "boolean", "children": [["property": "event", "value": "prop"]]], properties: ["prop": [1,2,3]])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateBoolean(node: ["operator": "boolean", "children": [["property": "event", "value": "prop"]]], properties: ["prop": []])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateBoolean(node: ["operator": "boolean", "children": [["property": "event", "value": "prop"]]], properties: ["prop": ["a":1]])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateBoolean(node: ["operator": "boolean", "children": [["property": "event", "value": "prop"]]], properties: ["prop": [:]])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateBoolean(node: ["operator": "boolean", "children": [["property": "event", "value": "prop"]]], properties: ["prop": Date(timeIntervalSince1970: 1)])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateBoolean(node: ["operator": "boolean", "children": [["property": "event", "value": "prop"]]], properties: ["prop": Date(timeIntervalSince1970: 0)])!)
+    }
+    
+    func testEvaluateDatetime() {
+        XCTAssertNil(SelectorEvaluator.evaluateDateTime(node: [:], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateDateTime(node: ["operator": "or"], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateDateTime(node: ["operator": "datetime"], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateDateTime(node: ["operator": "datetime", "children": []], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateDateTime(node: ["operator": "datetime", "children": [[], []]], properties: nil))
+        
+        XCTAssertNil(SelectorEvaluator.evaluateDateTime(node: ["operator": "datetime", "children": [["property": "event", "value": "prop"]]], properties: [:]))
+        XCTAssertNil(SelectorEvaluator.evaluateDateTime(node: ["operator": "datetime", "children": [["property": "event", "value": "prop"]]], properties: ["prop": true]))
+        XCTAssertEqual(SelectorEvaluator.evaluateDateTime(node: ["operator": "datetime", "children": [["property": "event", "value": "prop"]]], properties: ["prop": 10]), Date(timeIntervalSince1970: 10))
+        let df = DateFormatter.formatterForJSONDate();
+        let dt = df.date(from: "2019-02-01T12:01:01")
+        XCTAssertNotNil(dt)
+        XCTAssertEqual(SelectorEvaluator.evaluateDateTime(node: ["operator": "datetime", "children": [["property": "event", "value": "prop"]]], properties: ["prop": "2019-02-01T12:01:01"]), dt)
+        XCTAssertEqual(SelectorEvaluator.evaluateDateTime(node: ["operator": "datetime", "children": [["property": "event", "value": "prop"]]], properties: ["prop": dt!]), dt)
+        XCTAssertNil(SelectorEvaluator.evaluateDateTime(node: ["operator": "datetime", "children": [["property": "event", "value": "prop"]]], properties: ["prop": "2019-02-01T32:01:01"]))
+    }
+    
+    func testEvaluateList() {
+        XCTAssertNil(SelectorEvaluator.evaluateList(node: [:], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateList(node: ["operator": "or"], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateList(node: ["operator": "list"], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateList(node: ["operator": "list", "children": []], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateList(node: ["operator": "list", "children": [[], []]], properties: nil))
+        
+        XCTAssertNil(SelectorEvaluator.evaluateList(node: ["operator": "list", "children": [["property": "event", "value": "prop"]]], properties: [:]))
+        XCTAssertNil(SelectorEvaluator.evaluateList(node: ["operator": "list", "children": [["property": "event", "value": "prop"]]], properties: ["prop": 1]))
+        XCTAssertNil(SelectorEvaluator.evaluateList(node: ["operator": "list", "children": [["property": "event", "value": "prop"]]], properties: ["prop": ""]))
+        XCTAssertNil(SelectorEvaluator.evaluateList(node: ["operator": "list", "children": [["property": "event", "value": "prop"]]], properties: ["prop": [:]]))
+        
+        XCTAssertEqual(NSSet(array: SelectorEvaluator.evaluateList(node: ["operator": "list", "children": [["property": "event", "value": "prop"]]], properties: ["prop": []])!), NSSet(array: []))
+        XCTAssertEqual(NSSet(array: SelectorEvaluator.evaluateList(node: ["operator": "list", "children": [["property": "event", "value": "prop"]]], properties: ["prop": [1,2,3]])!), NSSet(array: [1,2,3]))
+    }
+    
+    func testEvaluateString() {
+        XCTAssertNil(SelectorEvaluator.evaluateString(node: [:], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateString(node: ["operator": "or"], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateString(node: ["operator": "string"], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateString(node: ["operator": "string", "children": []], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateString(node: ["operator": "string", "children": [[], []]], properties: nil))
+        
+        let df = DateFormatter.formatterForJSONDate()
+        let dt = df.date(from: "2019-01-01T00:00:00")
+        XCTAssertNotNil(dt)
+        XCTAssertEqual(SelectorEvaluator.evaluateString(node: ["operator": "string", "children": [["property": "event", "value": "prop"]]], properties: ["prop": dt!]), "2019-01-01T00:00:00")
+        XCTAssertEqual(SelectorEvaluator.evaluateString(node: ["operator": "string", "children": [["property": "event", "value": "prop"]]], properties: ["prop": 100]), "100")
+        XCTAssertEqual(SelectorEvaluator.evaluateString(node: ["operator": "string", "children": [["property": "event", "value": "prop"]]], properties: ["prop": []]), "[]")
+        XCTAssertEqual(SelectorEvaluator.evaluateString(node: ["operator": "string", "children": [["property": "event", "value": "prop"]]], properties: ["prop": [1,2,3]]), "[1,2,3]")
+        XCTAssertEqual(SelectorEvaluator.evaluateString(node: ["operator": "string", "children": [["property": "event", "value": "prop"]]], properties: ["prop": [:]]), "{}")
+        XCTAssertEqual(SelectorEvaluator.evaluateString(node: ["operator": "string", "children": [["property": "event", "value": "prop"]]], properties: ["prop": ["a":"b"]]), "{\"a\":\"b\"}")
+        XCTAssertEqual(SelectorEvaluator.evaluateString(node: ["operator": "string", "children": [["property": "event", "value": "prop"]]], properties: ["prop": true]), "true")
+    }
+    
+    func testEvaluateAnd() {
+        XCTAssertNil(SelectorEvaluator.evaluateAnd(node: [:], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateAnd(node: ["operator": "or"], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateAnd(node: ["operator": "and"], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateAnd(node: ["operator": "and", "children": []], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateAnd(node: ["operator": "and", "children": [[]]], properties: nil))
+        
+        XCTAssertTrue(SelectorEvaluator.evaluateAnd(node: ["operator": "and", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": true, "prop2": true])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateAnd(node: ["operator": "and", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": true, "prop2": false])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateAnd(node: ["operator": "and", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": false, "prop2": true])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateAnd(node: ["operator": "and", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": false, "prop2": false])!)
+    }
+    
+    func testEvaluateOr() {
+        XCTAssertNil(SelectorEvaluator.evaluateOr(node: [:], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateOr(node: ["operator": "and"], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateOr(node: ["operator": "or"], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateOr(node: ["operator": "or", "children": []], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateOr(node: ["operator": "or", "children": [[]]], properties: nil))
+        
+        XCTAssertTrue(SelectorEvaluator.evaluateOr(node: ["operator": "or", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": true, "prop2": true])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateOr(node: ["operator": "or", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": true, "prop2": false])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateOr(node: ["operator": "or", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": false, "prop2": true])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateOr(node: ["operator": "or", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": false, "prop2": false])!)
+    }
+    
+    func testEvaluateIn() {
+        XCTAssertNil(SelectorEvaluator.evaluateIn(node: [:], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateIn(node: ["operator": "and"], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateIn(node: ["operator": "in"], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateIn(node: ["operator": "in", "children": []], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateIn(node: ["operator": "in", "children": [[]]], properties: nil))
+        
+        XCTAssertTrue(SelectorEvaluator.evaluateIn(node: ["operator": "in", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": [1,2]])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateIn(node: ["operator": "in", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": "ab", "prop2": "abc"])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateIn(node: ["operator": "in", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": [11]])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateIn(node: ["operator": "in", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": "ab", "prop2": "bac"])!)
+        
+        XCTAssertFalse(SelectorEvaluator.evaluateIn(node: ["operator": "not in", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": [1,2]])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateIn(node: ["operator": "not in", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": "ab", "prop2": "abc"])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateIn(node: ["operator": "not in", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": [11]])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateIn(node: ["operator": "not in", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": "ab", "prop2": "bac"])!)
+    }
+    
+    func testEvaluatePlus() {
+        XCTAssertNil(SelectorEvaluator.evaluatePlus(node: [:], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluatePlus(node: ["operator": "and"], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluatePlus(node: ["operator": "+"], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluatePlus(node: ["operator": "+", "children": []], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluatePlus(node: ["operator": "+", "children": [[]]], properties: nil))
+        
+        XCTAssertNil(SelectorEvaluator.evaluatePlus(node: ["operator": "+", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": [1,2]]))
+        XCTAssertEqual(SelectorEvaluator.evaluatePlus(node: ["operator": "+", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": 2]) as? Double, 3)
+        XCTAssertEqual(SelectorEvaluator.evaluatePlus(node: ["operator": "+", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": "1", "prop2": "2"]) as? String, "12")
+    }
+    
+    func testEvaluateArithmetic() {
+        XCTAssertNil(SelectorEvaluator.evaluateArithmetic(node: [:], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateArithmetic(node: ["operator": "and"], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateArithmetic(node: ["operator": "-"], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateArithmetic(node: ["operator": "-", "children": []], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateArithmetic(node: ["operator": "-", "children": [[]]], properties: nil))
+        
+        XCTAssertEqual(SelectorEvaluator.evaluateArithmetic(node: ["operator": "-", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": 2]), -1)
+        XCTAssertEqual(SelectorEvaluator.evaluateArithmetic(node: ["operator": "*", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": 2]), 2)
+        XCTAssertEqual(SelectorEvaluator.evaluateArithmetic(node: ["operator": "/", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": 2]), 0.5)
+        XCTAssertNil(SelectorEvaluator.evaluateArithmetic(node: ["operator": "/", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": 0]))
+        XCTAssertNil(SelectorEvaluator.evaluateArithmetic(node: ["operator": "%", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": 0]))
+        XCTAssertEqual(SelectorEvaluator.evaluateArithmetic(node: ["operator": "%", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 0, "prop2": 1]), 0)
+        XCTAssertEqual(SelectorEvaluator.evaluateArithmetic(node: ["operator": "%", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": -1, "prop2": 2]), 1)
+        XCTAssertEqual(SelectorEvaluator.evaluateArithmetic(node: ["operator": "%", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": -1, "prop2": -2]), -1)
+        XCTAssertEqual(SelectorEvaluator.evaluateArithmetic(node: ["operator": "%", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": -2]), -1)
+    }
+    
+    func testEvaluateEquality() {
+        XCTAssertNil(SelectorEvaluator.evaluateEquality(node: [:], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateEquality(node: ["operator": "and"], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateEquality(node: ["operator": "=="], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateEquality(node: ["operator": "==", "children": []], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateEquality(node: ["operator": "==", "children": [[]]], properties: nil))
+        
+        XCTAssertTrue(SelectorEvaluator.evaluateEquality(node: ["operator": "==", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: [:])!)
+        
+        XCTAssertFalse(SelectorEvaluator.evaluateEquality(node: ["operator": "==", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": "1"])!)
+        
+        XCTAssertTrue(SelectorEvaluator.evaluateEquality(node: ["operator": "==", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": 1])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateEquality(node: ["operator": "==", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": 2])!)
+        
+        XCTAssertTrue(SelectorEvaluator.evaluateEquality(node: ["operator": "==", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": true, "prop2": true])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateEquality(node: ["operator": "==", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": false, "prop2": false])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateEquality(node: ["operator": "==", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": true, "prop2": false])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateEquality(node: ["operator": "==", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": false, "prop2": true])!)
+        
+        XCTAssertTrue(SelectorEvaluator.evaluateEquality(node: ["operator": "==", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": "abc", "prop2": "abc"])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateEquality(node: ["operator": "==", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": "abc", "prop2": "acb"])!)
+        
+        XCTAssertTrue(SelectorEvaluator.evaluateEquality(node: ["operator": "==", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": Date(timeIntervalSince1970: 100), "prop2": Date(timeIntervalSince1970: 100)])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateEquality(node: ["operator": "==", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": Date(timeIntervalSince1970: 100), "prop2": Date(timeIntervalSince1970: 101)])!)
+        
+        XCTAssertTrue(SelectorEvaluator.evaluateEquality(node: ["operator": "==", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": ["a": 1, "b": 2], "prop2": ["b": 2, "a": 1]])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateEquality(node: ["operator": "==", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": ["a": 1, "b": 2], "prop2": ["b": 1, "a": 2]])!)
+        
+        XCTAssertFalse(SelectorEvaluator.evaluateEquality(node: ["operator": "!=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: [:])!)
+        
+        XCTAssertTrue(SelectorEvaluator.evaluateEquality(node: ["operator": "!=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": "1"])!)
+        
+        XCTAssertFalse(SelectorEvaluator.evaluateEquality(node: ["operator": "!=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": 1])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateEquality(node: ["operator": "!=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": 2])!)
+        
+        XCTAssertFalse(SelectorEvaluator.evaluateEquality(node: ["operator": "!=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": true, "prop2": true])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateEquality(node: ["operator": "!=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": false, "prop2": false])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateEquality(node: ["operator": "!=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": true, "prop2": false])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateEquality(node: ["operator": "!=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": false, "prop2": true])!)
+        
+        XCTAssertFalse(SelectorEvaluator.evaluateEquality(node: ["operator": "!=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": "abc", "prop2": "abc"])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateEquality(node: ["operator": "!=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": "abc", "prop2": "acb"])!)
+        
+        XCTAssertFalse(SelectorEvaluator.evaluateEquality(node: ["operator": "!=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": Date(timeIntervalSince1970: 100), "prop2": Date(timeIntervalSince1970: 100)])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateEquality(node: ["operator": "!=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": Date(timeIntervalSince1970: 100), "prop2": Date(timeIntervalSince1970: 101)])!)
+        
+        XCTAssertFalse(SelectorEvaluator.evaluateEquality(node: ["operator": "!=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": ["a": 1, "b": 2], "prop2": ["b": 2, "a": 1]])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateEquality(node: ["operator": "!=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": ["a": 1, "b": 2], "prop2": ["b": 1, "a": 2]])!)
+    }
+    
+    func testEvaluateComparison() {
+        XCTAssertNil(SelectorEvaluator.evaluateComparison(node: [:], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateComparison(node: ["operator": "and"], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateComparison(node: ["operator": "<"], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateComparison(node: ["operator": "<", "children": []], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateComparison(node: ["operator": "<", "children": [[]]], properties: nil))
+        
+        XCTAssertFalse(SelectorEvaluator.evaluateComparison(node: ["operator": ">", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": 1])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateComparison(node: ["operator": ">", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": Date(timeIntervalSince1970: 1), "prop2": Date(timeIntervalSince1970: 1)])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateComparison(node: ["operator": ">", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": 2])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateComparison(node: ["operator": ">", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": Date(timeIntervalSince1970: 1), "prop2": Date(timeIntervalSince1970: 2)])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateComparison(node: ["operator": ">", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 2, "prop2": 1])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateComparison(node: ["operator": ">", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": Date(timeIntervalSince1970: 2), "prop2": Date(timeIntervalSince1970: 1)])!)
+        
+        XCTAssertTrue(SelectorEvaluator.evaluateComparison(node: ["operator": ">=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": 1])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateComparison(node: ["operator": ">=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": Date(timeIntervalSince1970: 1), "prop2": Date(timeIntervalSince1970: 1)])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateComparison(node: ["operator": ">=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": 2])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateComparison(node: ["operator": ">=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": Date(timeIntervalSince1970: 1), "prop2": Date(timeIntervalSince1970: 2)])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateComparison(node: ["operator": ">=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 2, "prop2": 1])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateComparison(node: ["operator": ">=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": Date(timeIntervalSince1970: 2), "prop2": Date(timeIntervalSince1970: 1)])!)
+        
+        XCTAssertFalse(SelectorEvaluator.evaluateComparison(node: ["operator": "<", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": 1])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateComparison(node: ["operator": "<", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": Date(timeIntervalSince1970: 1), "prop2": Date(timeIntervalSince1970: 1)])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateComparison(node: ["operator": "<", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": 2])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateComparison(node: ["operator": "<", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": Date(timeIntervalSince1970: 1), "prop2": Date(timeIntervalSince1970: 2)])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateComparison(node: ["operator": "<", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 2, "prop2": 1])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateComparison(node: ["operator": "<", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": Date(timeIntervalSince1970: 2), "prop2": Date(timeIntervalSince1970: 1)])!)
+        
+        XCTAssertTrue(SelectorEvaluator.evaluateComparison(node: ["operator": "<=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": 1])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateComparison(node: ["operator": "<=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": Date(timeIntervalSince1970: 1), "prop2": Date(timeIntervalSince1970: 1)])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateComparison(node: ["operator": "<=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": 2])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateComparison(node: ["operator": "<=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": Date(timeIntervalSince1970: 1), "prop2": Date(timeIntervalSince1970: 2)])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateComparison(node: ["operator": "<=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 2, "prop2": 1])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateComparison(node: ["operator": "<=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": Date(timeIntervalSince1970: 2), "prop2": Date(timeIntervalSince1970: 1)])!)
+        
+        XCTAssertTrue(SelectorEvaluator.evaluateComparison(node: ["operator": "<=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": "abc", "prop2": "abc"])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateComparison(node: ["operator": ">=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": "abc", "prop2": "abc"])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateComparison(node: ["operator": ">", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": "abc", "prop2": "ab"])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateComparison(node: ["operator": "<", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": "ab", "prop2": "abc"])!)
+        
+        XCTAssertNil(SelectorEvaluator.evaluateComparison(node: ["operator": "<=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": [1,2,3], "prop2": 1]))
+    }
+    
+    func testEvaluateDefined() {
+        XCTAssertNil(SelectorEvaluator.evaluateDefined(node: [:], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateDefined(node: ["operator": "or"], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateDefined(node: ["operator": "defined"], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateDefined(node: ["operator": "defined", "children": []], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateDefined(node: ["operator": "defined", "children": [[], []]], properties: nil))
+        
+        XCTAssertFalse(SelectorEvaluator.evaluateDefined(node: ["operator": "defined", "children": [["property": "event", "value": "prop"]]], properties: [:])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateDefined(node: ["operator": "defined", "children": [["property": "event", "value": "prop"]]], properties: ["prop": []])!)
+        
+        XCTAssertTrue(SelectorEvaluator.evaluateDefined(node: ["operator": "not defined", "children": [["property": "event", "value": "prop"]]], properties: [:])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateDefined(node: ["operator": "not defined", "children": [["property": "event", "value": "prop"]]], properties: ["prop": []])!)
+    }
+    
+    func testEvaluateNot() {
+        XCTAssertNil(SelectorEvaluator.evaluateNot(node: [:], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateNot(node: ["operator": "or"], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateNot(node: ["operator": "not"], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateNot(node: ["operator": "not", "children": []], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateNot(node: ["operator": "not", "children": [[], []]], properties: nil))
+        
+        XCTAssertTrue(SelectorEvaluator.evaluateNot(node: ["operator": "not", "children": [["property": "event", "value": "prop"]]], properties: [:])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateNot(node: ["operator": "not", "children": [["property": "event", "value": "prop"]]], properties: ["prop": false])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateNot(node: ["operator": "not", "children": [["property": "event", "value": "prop"]]], properties: ["prop": true])!)
+        XCTAssertNil(SelectorEvaluator.evaluateNot(node: ["operator": "not", "children": [["property": "event", "value": "prop"]]], properties: ["prop": []]))
+        XCTAssertNil(SelectorEvaluator.evaluateNot(node: ["operator": "not", "children": [["property": "event", "value": "prop"]]], properties: ["prop": 1]))
+        XCTAssertNil(SelectorEvaluator.evaluateNot(node: ["operator": "not", "children": [["property": "event", "value": "prop"]]], properties: ["prop": "1"]))
+        XCTAssertNil(SelectorEvaluator.evaluateNot(node: ["operator": "not", "children": [["property": "event", "value": "prop"]]], properties: ["prop": [:]]))
+    }
+    
+    func testEvaluateWindow() {
+        XCTAssertNil(TestSelectorEvaluator.evaluateWindow(value: [:]))
+        XCTAssertNil(TestSelectorEvaluator.evaluateWindow(value: ["window":[:]]))
+        XCTAssertNil(TestSelectorEvaluator.evaluateWindow(value: ["window":["value":[]]]))
+        XCTAssertNil(TestSelectorEvaluator.evaluateWindow(value: ["window":["value":1]]))
+        XCTAssertNil(TestSelectorEvaluator.evaluateWindow(value: ["window":["value":1, "unit": "blah"]]))
+        
+        XCTAssertEqual(TestSelectorEvaluator.evaluateWindow(value: ["window": ["value": -2, "unit": "hour"]]), Date(timeIntervalSince1970: 10000+(2*60*60)))
+        XCTAssertEqual(TestSelectorEvaluator.evaluateWindow(value: ["window": ["value": -2, "unit": "day"]]), Date(timeIntervalSince1970: 10000+(2*24*60*60)))
+        XCTAssertEqual(TestSelectorEvaluator.evaluateWindow(value: ["window": ["value": -2, "unit": "week"]]), Date(timeIntervalSince1970: 10000+(2*7*24*60*60)))
+        XCTAssertEqual(TestSelectorEvaluator.evaluateWindow(value: ["window": ["value": -2, "unit": "month"]]), Date(timeIntervalSince1970: 10000+(2*30*24*60*60)))
+        XCTAssertEqual(TestSelectorEvaluator.evaluateWindow(value: ["window": ["value": 2, "unit": "hour"]]), Date(timeIntervalSince1970: 10000+(-2*60*60)))
+    }
+    
+    func testEvaluateOperand() {
+        XCTAssertNil(SelectorEvaluator.evaluateOperand(node: [:], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateOperand(node: ["property": 1], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateOperand(node: ["property": "event"], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateOperand(node: ["property": "event", "value": 1], properties: nil))
+        
+        XCTAssertEqual(SelectorEvaluator.evaluateOperand(node: ["property": "event", "value": "prop"], properties: ["prop": Double(100)]) as? Double, 100)
+        XCTAssertEqual(SelectorEvaluator.evaluateOperand(node: ["property": "literal", "value": "prop"], properties: ["prop": Double(100)]) as? String, "prop")
+        XCTAssertEqual(TestSelectorEvaluator.evaluateOperand(node: ["property": "literal", "value": "now"], properties: ["prop": Double(100)]) as? Date, Date(timeIntervalSince1970: 10000))
+        XCTAssertEqual(TestSelectorEvaluator.evaluateOperand(node: ["property": "literal", "value": ["window": ["value": -1, "unit": "hour"]]], properties: ["prop": Double(100)]) as? Date, Date(timeIntervalSince1970: 10000+(60*60)))
+    }
+    
+    func testEvaluateOperator() {
+        XCTAssertNil(SelectorEvaluator.evaluateOperator(node: [:], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateOperator(node: ["operator": 1], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluateOperator(node: ["operator": "blah"], properties: nil))
+        
+        XCTAssertTrue(SelectorEvaluator.evaluateOperator(node: ["operator": "and", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": true, "prop2": true]) as! Bool)
+        XCTAssertTrue(SelectorEvaluator.evaluateOperator(node: ["operator": "or", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": true, "prop2": false]) as! Bool)
+        XCTAssertTrue(SelectorEvaluator.evaluateOperator(node: ["operator": "in", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": [1,2]]) as! Bool)
+        XCTAssertTrue(SelectorEvaluator.evaluateOperator(node: ["operator": "not in", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 12, "prop2": [1,2]]) as! Bool)
+        XCTAssertEqual(SelectorEvaluator.evaluateOperator(node: ["operator": "+", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": 2]) as! Double, 3)
+        XCTAssertEqual(SelectorEvaluator.evaluateOperator(node: ["operator": "-", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": 2]) as! Double, -1)
+        XCTAssertEqual(SelectorEvaluator.evaluateOperator(node: ["operator": "*", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": 2]) as! Double, 2)
+        XCTAssertEqual(SelectorEvaluator.evaluateOperator(node: ["operator": "/", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": 2]) as! Double, 0.5)
+        XCTAssertEqual(SelectorEvaluator.evaluateOperator(node: ["operator": "%", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": 2]) as! Double, 1)
+        XCTAssertTrue(SelectorEvaluator.evaluateOperator(node: ["operator": "==", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": false, "prop2": false]) as! Bool)
+        XCTAssertTrue(SelectorEvaluator.evaluateOperator(node: ["operator": "!=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": true, "prop2": false]) as! Bool)
+        XCTAssertTrue(SelectorEvaluator.evaluateOperator(node: ["operator": ">", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 2, "prop2": 1]) as! Bool)
+        XCTAssertTrue(SelectorEvaluator.evaluateOperator(node: ["operator": ">=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 2, "prop2": 2]) as! Bool)
+        XCTAssertTrue(SelectorEvaluator.evaluateOperator(node: ["operator": "<", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 0, "prop2": 1]) as! Bool)
+        XCTAssertTrue(SelectorEvaluator.evaluateOperator(node: ["operator": "<=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": 1]) as! Bool)
+        XCTAssertTrue(SelectorEvaluator.evaluateOperator(node: ["operator": "boolean", "children": [["property": "event", "value": "prop"]]], properties: ["prop": true]) as! Bool)
+        XCTAssertEqual(SelectorEvaluator.evaluateOperator(node: ["operator": "string", "children": [["property": "event", "value": "prop"]]], properties: ["prop": 100]) as! String, "100")
+        XCTAssertEqual(NSSet(array: SelectorEvaluator.evaluateOperator(node: ["operator": "list", "children": [["property": "event", "value": "prop"]]], properties: ["prop": [1,2,3]]) as! Array), NSSet(array: [1,2,3]))
+        XCTAssertEqual(SelectorEvaluator.evaluateOperator(node: ["operator": "number", "children": [["property": "event", "value": "prop"]]], properties: ["prop": "101"]) as! Double, 101)
+        let df = DateFormatter.formatterForJSONDate();
+        let dt = df.date(from: "2019-02-01T12:01:01")
+        XCTAssertNotNil(dt)
+        XCTAssertEqual(SelectorEvaluator.evaluateOperator(node: ["operator": "datetime", "children": [["property": "event", "value": "prop"]]], properties: ["prop": "2019-02-01T12:01:01"]) as? Date, dt)
+        XCTAssertTrue(SelectorEvaluator.evaluateOperator(node: ["operator": "defined", "children": [["property": "event", "value": "prop"]]], properties: ["prop": []]) as! Bool)
+        XCTAssertTrue(SelectorEvaluator.evaluateOperator(node: ["operator": "not defined", "children": [["property": "event", "value": "prop"]]], properties: [:]) as! Bool)
+        XCTAssertTrue(SelectorEvaluator.evaluateOperator(node: ["operator": "not", "children": [["property": "event", "value": "prop"]]], properties: ["prop": false]) as! Bool)
+    }
+    
+    func testEvaluate() {
+        XCTAssertFalse(SelectorEvaluator.evaluate(selector: [:], properties: nil))
+        XCTAssertFalse(SelectorEvaluator.evaluate(selector: ["operator": "unknown"], properties: ["prop": 1]))
+        XCTAssertTrue(SelectorEvaluator.evaluate(selector: ["operator": ">", "children": [["property": "event", "value": "prop1"], ["property": "literal", "value": ["window": ["value": 1, "unit": "hour"]]]]], properties: ["prop1": Date()]))
+    }
+}
+
+class TestSelectorEvaluator: SelectorEvaluator {
+    override class func getCurrentDate() -> Date {
+        return Date(timeIntervalSince1970: 10000)
+    }
+}

--- a/Mixpanel.podspec
+++ b/Mixpanel.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.libraries = 'icucore'
   s.ios.deployment_target = '8.0'
-  s.ios.source_files  = 'Mixpanel/**/*.{m,h}'
+  s.ios.source_files  = 'Mixpanel/**/*.{m,h,swift}'
   s.ios.exclude_files = 'Mixpanel/MixpanelWatchProperties.{m,h}'
   s.ios.public_header_files = 'Mixpanel/Mixpanel.h', 'Mixpanel/MixpanelPeople.h', 'Mixpanel/MPTweak.h', 'Mixpanel/MPTweakInline.h', 'Mixpanel/MPTweakInlineInternal.h', 'Mixpanel/MPTweakStore.h', 'Mixpanel/_MPTweakBindObserver.h'
   s.ios.private_header_files = 'Mixpanel/MixpanelPeoplePrivate.h', 'Mixpanel/MPNetworkPrivate.h', 'Mixpanel/MixpanelPrivate.h', 'Mixpanel/SessionMetadata.h'

--- a/Mixpanel.xcodeproj/project.pbxproj
+++ b/Mixpanel.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		05A0201422028E5800D04A3A /* MPDisplayTrigger.h in Headers */ = {isa = PBXBuildFile; fileRef = 05A0201222028E5800D04A3A /* MPDisplayTrigger.h */; };
+		05A0201522028E5800D04A3A /* MPDisplayTrigger.m in Sources */ = {isa = PBXBuildFile; fileRef = 05A0201322028E5800D04A3A /* MPDisplayTrigger.m */; };
 		37F9F7F31C2B8BFC00783DDB /* MPFoundation.h in Headers */ = {isa = PBXBuildFile; fileRef = 37F9F7F11C2B8BFC00783DDB /* MPFoundation.h */; };
 		511FC3591C2B74BD00DC4796 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7C170D451A4A05A000D9E0F2 /* Foundation.framework */; };
 		513243441D1B473100CBA9AA /* WatchKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 513243431D1B473100CBA9AA /* WatchKit.framework */; };
@@ -229,6 +231,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		05A0201222028E5800D04A3A /* MPDisplayTrigger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MPDisplayTrigger.h; sourceTree = "<group>"; };
+		05A0201322028E5800D04A3A /* MPDisplayTrigger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPDisplayTrigger.m; sourceTree = "<group>"; };
 		24A495E21D7E9CA5006A0742 /* app_extension_module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; name = app_extension_module.modulemap; path = Mixpanel/app_extension_module.modulemap; sourceTree = "<group>"; };
 		37F9F7F11C2B8BFC00783DDB /* MPFoundation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MPFoundation.h; path = Mixpanel/MPFoundation.h; sourceTree = "<group>"; };
 		511FC39D1C2B74BD00DC4796 /* Mixpanel.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Mixpanel.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -549,6 +553,8 @@
 		515B5A151CB6FBA500A34060 /* Notifications */ = {
 			isa = PBXGroup;
 			children = (
+				05A0201222028E5800D04A3A /* MPDisplayTrigger.h */,
+				05A0201322028E5800D04A3A /* MPDisplayTrigger.m */,
 				F11A5B051E3A915C004F750B /* MPTakeoverNotificationViewController~iphoneportrait.xib */,
 				F11A5B061E3A915C004F750B /* MPTakeoverNotificationViewController~iphonelandscape.xib */,
 				F11A5B071E3A915C004F750B /* MPTakeoverNotificationViewController~ipad.xib */,
@@ -945,6 +951,7 @@
 				E12FA3B31D4C0F2B009DF414 /* MPAbstractABTestDesignerMessage.h in Headers */,
 				7C170CDF1A4A035F00D9E0F2 /* MPABTestDesignerSnapshotResponseMessage.h in Headers */,
 				7C170CE11A4A035F00D9E0F2 /* MPABTestDesignerTweakRequestMessage.h in Headers */,
+				05A0201422028E5800D04A3A /* MPDisplayTrigger.h in Headers */,
 				7C170CD41A4A035F00D9E0F2 /* MPABTestDesignerConnection.h in Headers */,
 				7C170D301A4A035F00D9E0F2 /* MPValueTransformers.h in Headers */,
 				7C170CFA1A4A035F00D9E0F2 /* MPEventBinding.h in Headers */,
@@ -1246,6 +1253,7 @@
 				7C170D2A1A4A035F00D9E0F2 /* MPUIControlBinding.m in Sources */,
 				7C170D401A4A035F00D9E0F2 /* UIImage+MPImageEffects.m in Sources */,
 				7C170D341A4A035F00D9E0F2 /* MPWebSocket.m in Sources */,
+				05A0201522028E5800D04A3A /* MPDisplayTrigger.m in Sources */,
 				7C170D201A4A035F00D9E0F2 /* MPTweak.m in Sources */,
 				F13874C91E38327100808C36 /* MPMiniNotification.m in Sources */,
 				7C170CEA1A4A035F00D9E0F2 /* MPCGAffineTransformToNSDictionaryValueTransformer.m in Sources */,

--- a/Mixpanel.xcodeproj/project.pbxproj
+++ b/Mixpanel.xcodeproj/project.pbxproj
@@ -7,8 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		058229592213887D00352FC5 /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 058229582213887D00352FC5 /* JavaScriptCore.framework */; };
 		05A0201422028E5800D04A3A /* MPDisplayTrigger.h in Headers */ = {isa = PBXBuildFile; fileRef = 05A0201222028E5800D04A3A /* MPDisplayTrigger.h */; };
 		05A0201522028E5800D04A3A /* MPDisplayTrigger.m in Sources */ = {isa = PBXBuildFile; fileRef = 05A0201322028E5800D04A3A /* MPDisplayTrigger.m */; };
+		05DD7BBD2238975A0019FB42 /* SelectorEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05DD7BBC2238975A0019FB42 /* SelectorEvaluator.swift */; };
 		37F9F7F31C2B8BFC00783DDB /* MPFoundation.h in Headers */ = {isa = PBXBuildFile; fileRef = 37F9F7F11C2B8BFC00783DDB /* MPFoundation.h */; };
 		511FC3591C2B74BD00DC4796 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7C170D451A4A05A000D9E0F2 /* Foundation.framework */; };
 		513243441D1B473100CBA9AA /* WatchKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 513243431D1B473100CBA9AA /* WatchKit.framework */; };
@@ -231,8 +233,10 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		058229582213887D00352FC5 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 		05A0201222028E5800D04A3A /* MPDisplayTrigger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MPDisplayTrigger.h; sourceTree = "<group>"; };
 		05A0201322028E5800D04A3A /* MPDisplayTrigger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPDisplayTrigger.m; sourceTree = "<group>"; };
+		05DD7BBC2238975A0019FB42 /* SelectorEvaluator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectorEvaluator.swift; sourceTree = "<group>"; };
 		24A495E21D7E9CA5006A0742 /* app_extension_module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; name = app_extension_module.modulemap; path = Mixpanel/app_extension_module.modulemap; sourceTree = "<group>"; };
 		37F9F7F11C2B8BFC00783DDB /* MPFoundation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MPFoundation.h; path = Mixpanel/MPFoundation.h; sourceTree = "<group>"; };
 		511FC39D1C2B74BD00DC4796 /* Mixpanel.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Mixpanel.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -444,6 +448,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				058229592213887D00352FC5 /* JavaScriptCore.framework in Frameworks */,
 				E14FA8071F44DF17009B4533 /* UserNotifications.framework in Frameworks */,
 				E163D08E1EA69B4500DA4BF6 /* StoreKit.framework in Frameworks */,
 				515B5A231CB6FF8600A34060 /* libicucore.tbd in Frameworks */,
@@ -568,6 +573,7 @@
 				F13874C71E38327100808C36 /* MPMiniNotification.m */,
 				F17EB3511E393FD40002739C /* MPNotificationButton.h */,
 				F17EB3521E393FD40002739C /* MPNotificationButton.m */,
+				05DD7BBC2238975A0019FB42 /* SelectorEvaluator.swift */,
 			);
 			name = Notifications;
 			sourceTree = "<group>";
@@ -862,6 +868,7 @@
 		E1C2BDE01CFD5F9D0052172F /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				058229582213887D00352FC5 /* JavaScriptCore.framework */,
 				E14FA8061F44DF17009B4533 /* UserNotifications.framework */,
 				E163D08D1EA69B4500DA4BF6 /* StoreKit.framework */,
 				513243431D1B473100CBA9AA /* WatchKit.framework */,
@@ -935,11 +942,11 @@
 				E1F160D31E67A93500391AE3 /* MPNetwork.h in Headers */,
 				7C170D3D1A4A035F00D9E0F2 /* UIImage+MPAverageColor.h in Headers */,
 				F0ACBDEC1F8C46B400ABF03D /* MPConnectIntegrations.h in Headers */,
-				7C170CFC1A4A035F00D9E0F2 /* MPLogger.h in Headers */,
 				7C170D091A4A035F00D9E0F2 /* MPObjectSerializer.h in Headers */,
 				7C170CF81A4A035F00D9E0F2 /* MPEnumDescription.h in Headers */,
 				7C170D311A4A035F00D9E0F2 /* MPVariant.h in Headers */,
 				7C170D101A4A035F00D9E0F2 /* MPPropertyDescription.h in Headers */,
+				7C170CFC1A4A035F00D9E0F2 /* MPLogger.h in Headers */,
 				37F9F7F31C2B8BFC00783DDB /* MPFoundation.h in Headers */,
 				E12CE4361EA68A3C0023AA2D /* AutomaticEvents.h in Headers */,
 				513583971BD1BE50008EEDF1 /* UIView+MPHelpers.h in Headers */,
@@ -1093,6 +1100,7 @@
 				TargetAttributes = {
 					7C170C291A4A02F500D9E0F2 = {
 						CreatedOnToolsVersion = 6.1.1;
+						LastSwiftMigration = 1010;
 					};
 					E1F160AF1E677D2200391AE3 = {
 						CreatedOnToolsVersion = 8.2.1;
@@ -1216,6 +1224,7 @@
 				7C170CE41A4A035F00D9E0F2 /* MPABTestDesignerTweakResponseMessage.m in Sources */,
 				7C170CE01A4A035F00D9E0F2 /* MPABTestDesignerSnapshotResponseMessage.m in Sources */,
 				7C170CF91A4A035F00D9E0F2 /* MPEnumDescription.m in Sources */,
+				05DD7BBD2238975A0019FB42 /* SelectorEvaluator.swift in Sources */,
 				7C170D061A4A035F00D9E0F2 /* MPObjectIdentityProvider.m in Sources */,
 				519C548E1D131E6500407F56 /* MixpanelPeople.m in Sources */,
 				514733BE1CD7CCDB0098B23A /* MPResources.m in Sources */,
@@ -1466,6 +1475,7 @@
 		7C170C411A4A02F500D9E0F2 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ANALYZER_GCD_PERFORMANCE = NO;
 				CLANG_ANALYZER_LOCALIZABILITY_EMPTY_CONTEXT = YES;
@@ -1474,6 +1484,7 @@
 				CLANG_ANALYZER_SECURITY_FLOATLOOPCOUNTER = YES;
 				CLANG_ANALYZER_SECURITY_INSECUREAPI_RAND = YES;
 				CLANG_ANALYZER_SECURITY_INSECUREAPI_STRCPY = YES;
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -1485,6 +1496,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				INSTALL_PATH = "@rpath";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = Mixpanel/ios.modulemap;
 				OTHER_LDFLAGS = (
 					"-ObjC",
@@ -1492,12 +1504,17 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mixpanel.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "";
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "Mixpanel-Swift.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
 		7C170C421A4A02F500D9E0F2 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ANALYZER_GCD_PERFORMANCE = NO;
 				CLANG_ANALYZER_LOCALIZABILITY_EMPTY_CONTEXT = YES;
@@ -1506,6 +1523,7 @@
 				CLANG_ANALYZER_SECURITY_FLOATLOOPCOUNTER = YES;
 				CLANG_ANALYZER_SECURITY_INSECUREAPI_RAND = YES;
 				CLANG_ANALYZER_SECURITY_INSECUREAPI_STRCPY = YES;
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -1516,6 +1534,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				INSTALL_PATH = "@rpath";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = Mixpanel/ios.modulemap;
 				OTHER_LDFLAGS = (
 					"-ObjC",
@@ -1523,6 +1542,9 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mixpanel.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "";
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "Mixpanel-Swift.h";
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};

--- a/Mixpanel/MPDisplayTrigger.h
+++ b/Mixpanel/MPDisplayTrigger.h
@@ -4,7 +4,7 @@ extern NSString * const ANY_EVENT;
 
 @interface MPDisplayTrigger : NSObject
 
-@property (nonatomic, readonly) NSDictionary *jsonObject;
+@property (nonatomic, readonly) NSDictionary *rawJSON;
 @property (nonatomic, readonly) NSString *event;
 @property (nonatomic, readonly) NSDictionary *selector;
 

--- a/Mixpanel/MPDisplayTrigger.h
+++ b/Mixpanel/MPDisplayTrigger.h
@@ -1,0 +1,15 @@
+#import <Foundation/Foundation.h>
+
+extern NSString * const ANY_EVENT;
+
+@interface MPDisplayTrigger : NSObject
+
+@property (nonatomic, readonly) NSDictionary *jsonObject;
+@property (nonatomic, readonly) NSString *event;
+@property (nonatomic, readonly) NSDictionary *selector;
+
+- (instancetype)init __unavailable;
+- (instancetype)initWithJSONObject:(NSDictionary *)jsonObject;
+- (BOOL)matchesEvent:(NSDictionary *)event;
+
+@end

--- a/Mixpanel/MPDisplayTrigger.m
+++ b/Mixpanel/MPDisplayTrigger.m
@@ -1,6 +1,7 @@
 #import "MPLogger.h"
 #import "MPDisplayTrigger.h"
 #import "Mixpanel.h"
+#import "Mixpanel/Mixpanel-Swift.h"
 
 NSString * const ANY_EVENT = @"$any_event";
 
@@ -18,7 +19,7 @@ NSString * const ANY_EVENT = @"$any_event";
             event = @"";
         }
         
-        _jsonObject = object;
+        _rawJSON = object;
         _event = event;
         _selector = object[@"selector"];
     }
@@ -32,10 +33,12 @@ NSString * const ANY_EVENT = @"$any_event";
     }
     
     NSString *eventName = event[@"event"];
-    if ([eventName caseInsensitiveCompare:@""] == NSOrderedSame ||
-        [eventName caseInsensitiveCompare:ANY_EVENT] == NSOrderedSame ||
-        [eventName caseInsensitiveCompare:[self event]] == NSOrderedSame) {
-            return YES;
+    if ([eventName compare:ANY_EVENT] == NSOrderedSame ||
+        [eventName compare:[self event]] == NSOrderedSame) {
+        if ([_selector count] > 0) {
+            return [SelectorEvaluator evaluateWithSelector:_selector properties:event[@"properties"]];
+        }
+        return YES;
     }
     
     return NO;

--- a/Mixpanel/MPDisplayTrigger.m
+++ b/Mixpanel/MPDisplayTrigger.m
@@ -1,0 +1,44 @@
+#import "MPLogger.h"
+#import "MPDisplayTrigger.h"
+#import "Mixpanel.h"
+
+NSString * const ANY_EVENT = @"$any_event";
+
+@implementation MPDisplayTrigger
+
+- (instancetype)initWithJSONObject:(NSDictionary *)object {
+    if (self = [super init]) {
+        if (object == nil) {
+            MPLogError(@"display trigger json object should not be nil");
+            return nil;
+        }
+        
+        NSString *event = object[@"event"];
+        if ([event isEqual:[NSNull null]]) {
+            event = @"";
+        }
+        
+        _jsonObject = object;
+        _event = event;
+        _selector = object[@"selector"];
+    }
+    
+    return self;
+}
+
+- (BOOL)matchesEvent:(NSDictionary *)event {
+    if (event == nil) {
+        return NO;
+    }
+    
+    NSString *eventName = event[@"event"];
+    if ([eventName caseInsensitiveCompare:@""] == NSOrderedSame ||
+        [eventName caseInsensitiveCompare:ANY_EVENT] == NSOrderedSame ||
+        [eventName caseInsensitiveCompare:[self event]] == NSOrderedSame) {
+            return YES;
+    }
+    
+    return NO;
+}
+
+@end

--- a/Mixpanel/MPNotification.h
+++ b/Mixpanel/MPNotification.h
@@ -1,4 +1,5 @@
 #import <Foundation/Foundation.h>
+#import "MPDisplayTrigger.h"
 
 @interface MPNotification : NSObject
 
@@ -12,9 +13,12 @@
 @property (nonatomic, readonly) NSString *body;
 @property (nonatomic, readonly) NSUInteger bodyColor;
 @property (nonatomic, readonly) NSUInteger backgroundColor;
+@property (nonatomic, readonly) NSArray *displayTriggers;
 
 - (instancetype)init __unavailable;
 - (instancetype)initWithJSONObject:(NSDictionary *)jsonObject;
+- (BOOL)hasDisplayTriggers;
+- (BOOL)matchesEvent:(NSDictionary *)event;
 + (void)logNotificationError:(NSString *)field withValue:(id)value;
 
 @end

--- a/Mixpanel/MPNotification.m
+++ b/Mixpanel/MPNotification.m
@@ -77,6 +77,15 @@
             return nil;
         }
         
+        id rawDisplayTriggers = object[@"display_triggers"];
+        NSMutableArray *parsedDisplayTriggers = [NSMutableArray array];
+        if (rawDisplayTriggers != nil && [rawDisplayTriggers isKindOfClass:[NSArray class]]) {
+            for (id obj in rawDisplayTriggers) {
+                MPDisplayTrigger *displayTrigger = [[MPDisplayTrigger alloc] initWithJSONObject:obj];
+                [parsedDisplayTriggers addObject:displayTrigger];
+            }
+        }
+        
         _jsonDescription = object;
         _extrasDescription = object[@"extras"];
         _ID = ID.unsignedIntegerValue;
@@ -86,9 +95,25 @@
         _backgroundColor = backgroundColor.unsignedIntegerValue;
         _imageURL = imageURL;
         _image = nil;
+        _displayTriggers = parsedDisplayTriggers;
     }
 
     return self;
+}
+
+- (BOOL)hasDisplayTriggers {
+    return self.displayTriggers != nil && [self.displayTriggers count] > 0;
+}
+
+- (BOOL)matchesEvent:(NSDictionary *)event {
+    if ([self hasDisplayTriggers]) {
+        for (id trigger in self.displayTriggers) {
+            if([trigger matchesEvent:event]) {
+                return YES;
+            }
+        }
+    }
+    return NO;
 }
 
 - (NSString *)type {

--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -589,12 +589,14 @@ static NSString *defaultProjectToken;
             }
         }
 #if !MIXPANEL_NO_NOTIFICATION_AB_TEST_SUPPORT
+#if !TARGET_OS_WATCH
         for (MPNotification *notif in self.triggeredNotifications) {
             if ([notif matchesEvent:e]) {
                 [self showNotificationWithObject:notif];
                 break;
             }
         }
+#endif
 #endif //MIXPANEL_NO_NOTIFICATION_AB_TEST_SUPPORT
         // Always archive
         [self archiveEvents];
@@ -1919,6 +1921,8 @@ static void MixpanelReachabilityCallback(SCNetworkReachabilityRef target, SCNetw
 
             MPLogInfo(@"%@ decide check found %lu available notifs out of %lu total: %@", self, (unsigned long)unseenNotifications.count,
                       (unsigned long)self.notifications.count, unseenNotifications);
+            MPLogInfo(@"%@ decide check found %lu total triggered notifications %@", self, (unsigned long)self.triggeredNotifications.count,
+                      self.triggeredNotifications);
             MPLogInfo(@"%@ decide check found %lu variants: %@", self, (unsigned long)self.variants.count, self.variants);
             MPLogInfo(@"%@ decide check found %lu tracking events: %@", self, (unsigned long)self.eventBindings.count, self.eventBindings);
 

--- a/Mixpanel/MixpanelPrivate.h
+++ b/Mixpanel/MixpanelPrivate.h
@@ -111,7 +111,8 @@
 @property (nonatomic) BOOL decideResponseCached;
 @property (nonatomic) BOOL hasAddedObserver;
 @property (nonatomic, strong) NSNumber *automaticEventsEnabled;
-@property (nonatomic, strong) NSArray *notifications;
+@property (nonatomic, copy) NSArray *notifications;
+@property (nonatomic, copy) NSArray *triggeredNotifications;
 @property (nonatomic, strong) id currentlyShowingNotification;
 @property (nonatomic, strong) NSMutableSet *shownNotifications;
 

--- a/Mixpanel/SelectorEvaluator.swift
+++ b/Mixpanel/SelectorEvaluator.swift
@@ -1,0 +1,565 @@
+//
+//  SelectorEvaluator.swift
+//  Mixpanel
+//
+//  Created by Madhu Palani on 3/12/19.
+//  Copyright © 2019 Mixpanel. All rights reserved.
+//
+//  This file is a copy of <github link with commit>
+//
+
+import Foundation
+
+extension DateFormatter {
+    static func formatterForJSONDate() -> DateFormatter {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        return formatter
+    }
+}
+
+public typealias Properties = [String: Any]
+
+public class SelectorEvaluator: NSObject {
+    // Key words
+    static let OPERATOR_KEY = "operator"
+    static let CHILDREN_KEY = "children"
+    static let PROPERTY_KEY = "property"
+    static let VALUE_KEY = "value"
+    static let EVENT_KEY = "event"
+    static let LITERAL_KEY = "literal"
+    static let WINDOW_KEY = "window"
+    static let UNIT_KEY = "unit"
+    static let HOUR_KEY = "hour"
+    static let DAY_KEY = "day"
+    static let WEEK_KEY = "week"
+    static let MONTH_KEY = "month"
+    // Typecast operators
+    static let BOOLEAN_OPERATOR = "boolean"
+    static let DATETIME_OPERATOR = "datetime"
+    static let LIST_OPERATOR = "list"
+    static let NUMBER_OPERATOR = "number"
+    static let STRING_OPERATOR = "string"
+    // Binary operators
+    static let AND_OPERATOR = "and"
+    static let OR_OPERATOR = "or"
+    static let IN_OPERATOR = "in"
+    static let NOT_IN_OPERATOR = "not in"
+    static let PLUS_OPERATOR = "+"
+    static let MINUS_OPERATOR = "-"
+    static let MUL_OPERATOR = "*"
+    static let DIV_OPERATOR = "/"
+    static let MOD_OPERATOR = "%"
+    static let EQUALS_OPERATOR = "=="
+    static let NOT_EQUALS_OPERATOR = "!="
+    static let GREATER_THAN_OPERATOR = ">"
+    static let GREATER_THAN_EQUAL_OPERATOR = ">="
+    static let LESS_THAN_OPERATOR = "<"
+    static let LESS_THAN_EQUAL_OPERATOR = "<="
+    // Unary operators
+    static let NOT_OPERATOR = "not"
+    static let DEFINED_OPERATOR = "defined"
+    static let NOT_DEFINED_OPERATOR = "not defined"
+    // Special words
+    static let NOW_LITERAL = "now"
+    
+    // private const
+    private static let LEFT = 0
+    private static let RIGHT = 1
+    
+    // For testing purposes
+    class func getCurrentDate() -> Date {
+        return Date();
+    }
+    
+    class func toNumber(value: Any?) -> Double? {
+        if let val = value {
+            switch val {
+            case let bool as Bool:
+                return bool ? 1 : 0
+            case let date as Date:
+                return date.timeIntervalSince1970 > 0 ? date.timeIntervalSince1970 : nil
+            case let num as NSNumber:
+                return num.doubleValue
+            case let str as String:
+                if let int = Int(str) {
+                    return Double(int)
+                }
+                if let double = Double(str) {
+                    return double
+                }
+                return 0.0
+            default:
+                return nil
+            }
+        }
+        return nil
+    }
+    
+    class func toBoolean(value: Any?) -> Bool {
+        if let val = value {
+            switch val {
+            case let bool as Bool:
+                return bool
+            case let num as NSNumber:
+                return num.doubleValue != 0 ? true : false
+            case let str as String:
+                return str.count > 0 ? true : false
+            case let arr as [Any?]:
+                return arr.count > 0 ? true : false
+            case let dict as [String: Any]:
+                return dict.count > 0 ? true : false
+            case let date as Date:
+                return date.timeIntervalSince1970 > 0 ? true : false
+            default:
+                return false
+            }
+        }
+        return false
+    }
+    
+    class func evaluateNumber(node: [String: Any], properties: Properties?) -> Double? {
+        guard let op = node[OPERATOR_KEY] as? String, op == NUMBER_OPERATOR else {
+            return nil
+        }
+        guard let children = node[CHILDREN_KEY] as? [[String: Any]], children.count == 1 else {
+            return nil
+        }
+        
+        return toNumber(value: evaluateNode(node: children[LEFT], properties: properties))
+    }
+    
+    class func evaluateBoolean(node: [String: Any], properties: Properties?) -> Bool? {
+        guard let op = node[OPERATOR_KEY] as? String, op == BOOLEAN_OPERATOR else {
+            return nil
+        }
+        guard let children = node[CHILDREN_KEY] as? [[String: Any]], children.count == 1 else {
+            return nil
+        }
+        
+        return toBoolean(value: evaluateNode(node: children[LEFT], properties: properties))
+    }
+    
+    class func evaluateDateTime(node: [String: Any], properties: Properties?) -> Date? {
+        guard let op = node[OPERATOR_KEY] as? String, op == DATETIME_OPERATOR else {
+            return nil
+        }
+        guard let children = node[CHILDREN_KEY] as? [[String: Any]], children.count == 1 else {
+            return nil
+        }
+        
+        if let value = evaluateNode(node: children[LEFT], properties: properties) {
+            switch value {
+            case _ as Bool:
+                return nil
+            case let num as NSNumber:
+                return Date(timeIntervalSince1970: num.doubleValue)
+            case let str as String:
+                let dateFormatter = DateFormatter.formatterForJSONDate()
+                if let date = dateFormatter.date(from: str) {
+                    return date
+                }
+                return nil
+            case let date as Date:
+                return date
+            default:
+                return nil
+            }
+        }
+        return nil
+    }
+    
+    class func evaluateList(node: [String: Any], properties: Properties?) -> [Any]? {
+        guard let op = node[OPERATOR_KEY] as? String, op == LIST_OPERATOR else {
+            return nil
+        }
+        guard let children = node[CHILDREN_KEY] as? [[String: Any]], children.count == 1 else {
+            return nil
+        }
+        
+        if let value = evaluateNode(node: children[LEFT], properties: properties) as? [Any] {
+            return value
+        }
+        return nil
+    }
+    
+    private class func jsonStringify(value: Any) -> String? {
+        guard let jsonData = try? JSONSerialization.data(withJSONObject: value) else {
+            return nil
+        }
+        return String(data: jsonData, encoding: .utf8)
+    }
+    
+    class func evaluateString(node: [String: Any], properties: Properties?) -> String? {
+        guard let op = node[OPERATOR_KEY] as? String, op == STRING_OPERATOR else {
+            return nil
+        }
+        guard let children = node[CHILDREN_KEY] as? [[String: Any]], children.count == 1 else {
+            return nil
+        }
+        
+        if let value = evaluateNode(node: children[LEFT], properties: properties) {
+            switch value {
+            case let bool as Bool:
+                return String(bool)
+            case let dt as Date:
+                return DateFormatter.formatterForJSONDate().string(from: dt)
+            case let num as NSNumber:
+                return num.stringValue
+            case let arr as [Any]:
+                return jsonStringify(value: arr)
+            case let obj as [String: Any]:
+                return jsonStringify(value: obj)
+            default:
+                return nil
+            }
+        }
+        return nil
+    }
+    
+    class func evaluateAnd(node: [String: Any], properties: Properties?) -> Bool? {
+        guard let op = node[OPERATOR_KEY] as? String, op == AND_OPERATOR else {
+            return nil
+        }
+        guard let children = node[CHILDREN_KEY] as? [[String: Any]], children.count == 2 else {
+            return nil
+        }
+        
+        return toBoolean(value: evaluateNode(node: children[LEFT], properties: properties)) && toBoolean(value: evaluateNode(node: children[RIGHT], properties: properties))
+    }
+    
+    class func evaluateOr(node: [String: Any], properties: Properties?) -> Bool? {
+        guard let op = node[OPERATOR_KEY] as? String, op == OR_OPERATOR else {
+            return nil
+        }
+        guard let children = node[CHILDREN_KEY] as? [[String: Any]], children.count == 2 else {
+            return nil
+        }
+        
+        return toBoolean(value: evaluateNode(node: children[LEFT], properties: properties)) || toBoolean(value: evaluateNode(node: children[RIGHT], properties: properties))
+    }
+    
+    class func evaluateIn(node: [String: Any], properties: Properties?) -> Bool? {
+        let inOperators = [IN_OPERATOR, NOT_IN_OPERATOR]
+        guard let op = node[OPERATOR_KEY] as? String, inOperators.contains(op) else {
+            return nil
+        }
+        guard let children = node[CHILDREN_KEY] as? [[String: Any]], children.count == 2 else {
+            return nil
+        }
+        
+        let l = evaluateNode(node: children[LEFT], properties: properties)
+        let r = evaluateNode(node: children[RIGHT], properties: properties)
+        var b = false
+        
+        switch (l, r) {
+        case (let lStr as String, let rStr as String):
+            b = rStr.contains(lStr)
+            break
+        case (_, let rArr as [Any]):
+            if let l = l {
+                b = NSSet(array: rArr).contains(l)
+            }
+            break
+        default:
+            b = false
+        }
+        
+        return op == IN_OPERATOR ? b : !b
+    }
+    
+    class func evaluatePlus(node: [String: Any], properties: Properties?) -> Any? {
+        guard let op = node[OPERATOR_KEY] as? String, op == PLUS_OPERATOR else {
+            return nil
+        }
+        guard let children = node[CHILDREN_KEY] as? [[String: Any]], children.count == 2 else {
+            return nil
+        }
+        
+        let l = evaluateNode(node: children[LEFT], properties: properties)
+        let r = evaluateNode(node: children[RIGHT], properties: properties)
+        
+        switch (l, r) {
+        case (let lStr as String, let rStr as String):
+            return "\(lStr)\(rStr)"
+        case (let lNum as NSNumber, let rNum as NSNumber):
+            return lNum.doubleValue + rNum.doubleValue
+        default:
+            return nil
+        }
+    }
+    
+    class func evaluateArithmetic(node: [String: Any], properties: Properties?) -> Double? {
+        let arithmeticOperators = [MINUS_OPERATOR, MUL_OPERATOR, DIV_OPERATOR, MOD_OPERATOR]
+        guard let op = node[OPERATOR_KEY] as? String, arithmeticOperators.contains(op) else {
+            return nil
+        }
+        guard let children = node[CHILDREN_KEY] as? [[String: Any]], children.count == 2 else {
+            return nil
+        }
+        
+        let l = evaluateNode(node: children[LEFT], properties: properties)
+        let r = evaluateNode(node: children[RIGHT], properties: properties)
+        
+        switch (l, r) {
+        case (let lNum as NSNumber, let rNum as NSNumber):
+            let ld = lNum.doubleValue
+            let rd = rNum.doubleValue
+            switch op {
+            case MINUS_OPERATOR:
+                return ld - rd
+            case MUL_OPERATOR:
+                return ld * rd
+            case DIV_OPERATOR:
+                return rd != 0 ? ld / rd : nil
+            case MOD_OPERATOR:
+                if (rd == 0) {
+                    return nil
+                }
+                if (ld == 0) {
+                    return 0
+                }
+                if ((ld < 0 && rd > 0) || (ld > 0 && rd < 0)) {
+                    return -(floor(ld/rd) * rd - ld)
+                }
+                return ld.truncatingRemainder(dividingBy: rd)
+            default:
+                return nil
+            }
+        default:
+            return nil
+        }
+    }
+    
+    private class func equals(l: Any?, r: Any?) -> Bool {
+        switch (l, r) {
+        case (nil, nil):
+            return true
+        case (let lBool as Bool, let rBool as Bool):
+            return lBool == rBool
+        case (let lNum as NSNumber, let rNum as NSNumber):
+            return lNum.isEqual(to: rNum)
+        case (let lStr as String, let rStr as String):
+            return lStr == rStr
+        case (let lDate as Date, let rDate as Date):
+            return lDate == rDate
+        case (let lDict as [String: Any], let rDict as [String: Any]):
+            return NSDictionary(dictionary: lDict).isEqual(to: rDict)
+        case (let lArr as [Any], let rArr as [Any]):
+            return NSArray(array: lArr).isEqual(to: rArr)
+        default:
+            return false
+        }
+    }
+    
+    class func evaluateEquality(node: [String: Any], properties: Properties?) -> Bool? {
+        let supportedOperators = [EQUALS_OPERATOR, NOT_EQUALS_OPERATOR]
+        guard let op = node[OPERATOR_KEY] as? String, supportedOperators.contains(op) else {
+            return nil
+        }
+        guard let children = node[CHILDREN_KEY] as? [[String: Any]], children.count == 2 else {
+            return nil
+        }
+        
+        let l = evaluateNode(node: children[LEFT], properties: properties)
+        let r = evaluateNode(node: children[RIGHT], properties: properties)
+        let b = equals(l: l, r: r)
+        
+        return op == NOT_EQUALS_OPERATOR ? !b : b
+    }
+    
+    private class func compareDoubles(ld: Double, rd: Double, op: String) -> Bool? {
+        switch(op) {
+        case GREATER_THAN_OPERATOR:
+            return ld > rd
+        case GREATER_THAN_EQUAL_OPERATOR:
+            return ld >= rd
+        case LESS_THAN_OPERATOR:
+            return ld < rd
+        case LESS_THAN_EQUAL_OPERATOR:
+            return ld <= rd
+        default:
+            return nil
+        }
+    }
+    
+    class func evaluateComparison(node: [String: Any], properties: Properties?) -> Bool? {
+        let supportedOperators = [GREATER_THAN_OPERATOR, GREATER_THAN_EQUAL_OPERATOR, LESS_THAN_OPERATOR, LESS_THAN_EQUAL_OPERATOR]
+        guard let op = node[OPERATOR_KEY] as? String, supportedOperators.contains(op) else {
+            return nil
+        }
+        guard let children = node[CHILDREN_KEY] as? [[String: Any]], children.count == 2 else {
+            return nil
+        }
+        
+        let l = evaluateNode(node: children[LEFT], properties: properties)
+        let r = evaluateNode(node: children[RIGHT], properties: properties)
+        switch (l, r) {
+        case (let lNum as NSNumber, let rNum as NSNumber):
+            return compareDoubles(ld: lNum.doubleValue, rd: rNum.doubleValue, op: op)
+        case (let lDate as Date, let rDate as Date):
+            return compareDoubles(ld: lDate.timeIntervalSince1970, rd: rDate.timeIntervalSince1970, op: op)
+        case (let lStr as String, let rStr as String):
+            switch op {
+            case GREATER_THAN_OPERATOR:
+                return lStr.lowercased() > rStr.lowercased()
+            case GREATER_THAN_EQUAL_OPERATOR:
+                return lStr.lowercased() >= rStr.lowercased()
+            case LESS_THAN_OPERATOR:
+                return lStr.lowercased() < rStr.lowercased()
+            case LESS_THAN_EQUAL_OPERATOR:
+                return lStr.lowercased() <= rStr.lowercased()
+            default:
+                return nil
+            }
+        default:
+            return nil
+        }
+    }
+    
+    class func evaluateDefined(node: [String: Any], properties: Properties?) -> Bool? {
+        let supportedOperators = [DEFINED_OPERATOR, NOT_DEFINED_OPERATOR]
+        guard let op = node[OPERATOR_KEY] as? String, supportedOperators.contains(op) else {
+            return nil
+        }
+        guard let children = node[CHILDREN_KEY] as? [[String: Any]], children.count == 1 else {
+            return nil
+        }
+        
+        let b = evaluateNode(node: children[LEFT], properties: properties) != nil ? true : false
+        return op == DEFINED_OPERATOR ? b : !b
+    }
+    
+    class func evaluateNot(node: [String: Any], properties: Properties?) -> Bool? {
+        guard let op = node[OPERATOR_KEY] as? String, op == NOT_OPERATOR else {
+            return nil
+        }
+        guard let children = node[CHILDREN_KEY] as? [[String: Any]], children.count == 1 else {
+            return nil
+        }
+        
+        let v = evaluateNode(node: children[LEFT], properties: properties)
+        switch (v) {
+        case let b as Bool:
+            return !b
+        case nil:
+            return true
+        default:
+            return nil
+        }
+    }
+    
+    class func evaluateWindow(value: [String: Any]) -> Date? {
+        guard let window = value[WINDOW_KEY] as? [String: Any] else {
+            return nil
+        }
+        
+        guard let value = window[VALUE_KEY] as? NSNumber else {
+            return nil
+        }
+        
+        guard let unit = window[UNIT_KEY] as? String else {
+            return nil
+        }
+        let date = getCurrentDate()
+        switch unit {
+        case HOUR_KEY:
+            return date.addingTimeInterval(-1 * value.doubleValue * 60 * 60)
+        case DAY_KEY:
+            return date.addingTimeInterval(-1 * value.doubleValue * 24 * 60 * 60)
+        case WEEK_KEY:
+            return date.addingTimeInterval(-1 * value.doubleValue * 7 * 24 * 60 * 60)
+        case MONTH_KEY:
+            return date.addingTimeInterval(-1 * value.doubleValue * 30 * 24 * 60 * 60)
+        default:
+            return nil
+        }
+    }
+    
+    class func evaluateOperand(node: [String: Any], properties: Properties?) -> Any? {
+        guard let property = node[PROPERTY_KEY] as? String else {
+            return nil
+        }
+        
+        guard let value = node[VALUE_KEY] else {
+            return nil
+        }
+        
+        switch property {
+        case EVENT_KEY:
+            guard let valueStr = value as? String else {
+                return nil
+            }
+            return properties?[valueStr]
+        case LITERAL_KEY:
+            switch value {
+            case let valueStr as String:
+                if valueStr == NOW_LITERAL {
+                    return getCurrentDate()
+                }
+                return valueStr
+            case let valueObj as [String: Any]:
+                return evaluateWindow(value: valueObj)
+            default:
+                return value
+            }
+        default:
+            return nil
+        }
+    }
+    
+    class func evaluateOperator(node: [String: Any], properties: Properties?) -> Any? {
+        guard let op = node[OPERATOR_KEY] as? String else {
+            return nil
+        }
+        
+        switch op {
+        case AND_OPERATOR:
+            return evaluateAnd(node: node, properties: properties)
+        case OR_OPERATOR:
+            return evaluateOr(node: node, properties: properties)
+        case IN_OPERATOR, NOT_IN_OPERATOR:
+            return evaluateIn(node: node, properties: properties)
+        case PLUS_OPERATOR:
+            return evaluatePlus(node: node, properties: properties)
+        case MINUS_OPERATOR, MUL_OPERATOR, MOD_OPERATOR, DIV_OPERATOR:
+            return evaluateArithmetic(node: node, properties: properties)
+        case EQUALS_OPERATOR, NOT_EQUALS_OPERATOR:
+            return evaluateEquality(node: node, properties: properties)
+        case GREATER_THAN_OPERATOR, GREATER_THAN_EQUAL_OPERATOR, LESS_THAN_OPERATOR, LESS_THAN_EQUAL_OPERATOR:
+            return evaluateComparison(node: node, properties: properties)
+        case BOOLEAN_OPERATOR:
+            return evaluateBoolean(node: node, properties: properties)
+        case STRING_OPERATOR:
+            return evaluateString(node: node, properties: properties)
+        case LIST_OPERATOR:
+            return evaluateList(node: node, properties: properties)
+        case NUMBER_OPERATOR:
+            return evaluateNumber(node: node, properties: properties)
+        case DATETIME_OPERATOR:
+            return evaluateDateTime(node: node, properties: properties)
+        case DEFINED_OPERATOR, NOT_DEFINED_OPERATOR:
+            return evaluateDefined(node: node, properties: properties)
+        case NOT_OPERATOR:
+            return evaluateNot(node: node, properties: properties)
+        default:
+            return nil
+        }
+    }
+    
+    class func evaluateNode(node: [String: Any], properties: Properties?) -> Any? {
+        if let _ = node[PROPERTY_KEY] {
+            return evaluateOperand(node: node, properties: properties)
+        }
+        
+        return evaluateOperator(node: node, properties: properties)
+    }
+    
+    @objc public class func evaluate(selector: [String: Any], properties: Properties?) -> Bool {
+        if let value = SelectorEvaluator.evaluateOperator(node: selector, properties: properties) {
+            return SelectorEvaluator.toBoolean(value: value)
+        }
+        return false
+    }
+}


### PR DESCRIPTION
**Event Triggered InApps**

Currently users have no control over when an InApp notification shows up. With this release users can now control when an InApp gets displayed based on an event that they track within their app. This "trigger" event is defined during message creation. You can additionally filter the event based on properties that are tracked along with the event for even finer controls.