### PR TITLE
remove the sync archive after the exception handler being triggered

### DIFF
--- a/Mixpanel/MixpanelExceptionHandler.m
+++ b/Mixpanel/MixpanelExceptionHandler.m
@@ -130,9 +130,6 @@ void MPHandleException(NSException *exception) {
         NSMutableDictionary *properties = [[NSMutableDictionary alloc] init];
         [properties setValue:[exception reason] forKey:@"$ae_crashed_reason"];
         [instance track:@"$ae_crashed" properties:properties];
-        dispatch_sync(instance.serialQueue, ^{
-            [instance archive];
-        });
     }
     NSLog(@"Encountered an uncaught exception. All Mixpanel instances were archived.");
 }


### PR DESCRIPTION
This is not needed cause `track` will do the archive and call it in sync will cause potential crashes