### PR TITLE
Opt-out default state won't override user opt out local persistence

### DIFF
--- a/HelloMixpanel/HelloMixpanelTests/MixpanelOptOutTests.m
+++ b/HelloMixpanel/HelloMixpanelTests/MixpanelOptOutTests.m
@@ -45,6 +45,26 @@
     [MPSwizzler unswizzleSelector:@selector(track:) onClass:[Mixpanel class] named:@"Swizzle Mixpanel.track"];
 }
 
+- (void)testTrackShouldBeTriggeredDuringInitializedWithOptedOutYESButPrevouslyOptedIn
+{
+    stubTrack();
+    stubEngage();
+    __block NSInteger trackCount = 0;
+    [MPSwizzler swizzleSelector:@selector(track:) onClass:[Mixpanel class] withBlock:^(id obj, SEL sel){
+        trackCount++;
+    } named:@"Swizzle Mixpanel.track"];
+    
+    NSString *tokenId = [self randomTokenId];
+    self.mixpanel = [Mixpanel sharedInstanceWithToken:tokenId optOutTrackingByDefault:YES];
+    [self.mixpanel optInTracking];
+    
+    self.mixpanel = [Mixpanel sharedInstanceWithToken:tokenId optOutTrackingByDefault:YES];
+    [self.mixpanel track:@"test"];
+    XCTAssertTrue(trackCount == 1, @"init default opted out->optedIn->init default opted out, track call should be triggered during initialization.");
+    
+    [MPSwizzler unswizzleSelector:@selector(track:) onClass:[Mixpanel class] named:@"Swizzle Mixpanel.track"];
+}
+
 - (void)testAutoTrackEventsShouldNotBeQueuedDuringInitializedWithOptedOutYES
 {
     stubTrack();

--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -173,7 +173,10 @@ static NSString *defaultProjectToken;
         [self setUpListeners];
         [self unarchive];
 
-        if (optOutTrackingByDefault) {
+        // check whether we should opt out by default
+        // note: we don't override opt out persistence here since opt-out default state is often
+        // used as an initial state while GDPR information is being collected
+        if (optOutTrackingByDefault && ([self hasOptedOutTracking] || self.optOutStatusNotSet)) {
             [self optOutTracking];
         }
 
@@ -1371,6 +1374,7 @@ typedef NSDictionary*(^PropertyUpdate)(NSDictionary*);
 {
     NSNumber *optOutStatus = (NSNumber *)[Mixpanel unarchiveOrDefaultFromFile:[self optOutFilePath] asClass:[NSNumber class]];
     self.optOutStatus = [optOutStatus boolValue];
+    self.optOutStatusNotSet = (optOutStatus == nil);
 }
 
 #pragma mark - Application Helpers

--- a/Mixpanel/MixpanelPrivate.h
+++ b/Mixpanel/MixpanelPrivate.h
@@ -124,6 +124,7 @@
 @property (nonatomic, strong) NSSet *eventBindings;
 
 @property (nonatomic, assign) BOOL optOutStatus;
+@property (nonatomic, assign) BOOL optOutStatusNotSet;
 
 @property (nonatomic, strong) NSString *savedUrbanAirshipChannelID;
 


### PR DESCRIPTION
Change the default behavior for setting `optOutTrackingByDefault` in  the Mixpanel initialization method.
- We will not override opt out persistence with `optOutTrackingByDefault` the flag since opt-out default state is supposed to be used as an initial state while GDPR information is being collected