### PR TITLE
Xcode11 support and fix crash with MixpanelExceptionHandler in iOS 13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_install:
   - gem install fourflusher
   - gem uninstall cocoapods --force -a -q -I -x
   - gem install cocoapods -v 1.6.1
-osx_image: xcode10.2
+osx_image: xcode11
 branches:
   only:
   - master
@@ -14,7 +14,7 @@ env:
   - SCHEME="[iOS] HelloMixpanel"
   matrix:
     - DESTINATION="OS=11.1,name=iPhone 6s" RUN_TESTS="YES" POD_LINT="YES" 
-    - DESTINATION="OS=12.2,name=iPhone X" RUN_TESTS="YES" POD_LINT="YES" 
+    - DESTINATION="OS=13.0,name=iPhone 11" RUN_TESTS="YES" POD_LINT="YES" 
 podfile: HelloMixpanel/podfile
 script:
 - set -o pipefail

--- a/Mixpanel/MixpanelExceptionHandler.m
+++ b/Mixpanel/MixpanelExceptionHandler.m
@@ -24,7 +24,7 @@ static const atomic_int_fast32_t UncaughtExceptionMaximum = 10;
 
 @property (nonatomic) NSUncaughtExceptionHandler *defaultExceptionHandler;
 @property (nonatomic, unsafe_unretained) struct sigaction *prev_signal_handlers;
-@property (nonatomic, strong) NSHashTable *mixpanelInstances;
+@property (nonatomic, strong) NSMutableArray *mixpanelInstances;
 
 @end
 
@@ -130,11 +130,11 @@ void MPHandleException(NSException *exception) {
 
 - (void) mp_handleUncaughtException:(NSException *)exception {
     // Archive the values for each Mixpanel instance
-    for (Mixpanel *instance in self.mixpanelInstances) {
+    [self.mixpanelInstances enumerateObjectsUsingBlock:^(Mixpanel *instance, NSUInteger idx, BOOL * _Nonnull stop) {
         NSMutableDictionary *properties = [[NSMutableDictionary alloc] init];
         [properties setValue:[exception reason] forKey:@"$ae_crashed_reason"];
         [instance track:@"$ae_crashed" properties:properties];
-    }
+    }];
     MPLogWarning(@"Encountered an uncaught exception. All Mixpanel instances were archived.");
 }
 

--- a/release.py
+++ b/release.py
@@ -3,9 +3,9 @@ import argparse
 import subprocess
 
 
-parser = argparse.ArgumentParser(description='Release Mixpanel Swift SDK')
+parser = argparse.ArgumentParser(description='Release Mixpanel Objective-C SDK')
 parser.add_argument('--old', help='old version number', action="store")
-parser.add_argument('--new', help='new version for the release', action="store")
+parser.add_argument('--new', help='new version number for the release', action="store")
 args = parser.parse_args()
 
 def bump_version():


### PR DESCRIPTION
Change `NSHashtable`  to `NSMutableArray` to avoid crash in iOS 13 with [NSConcreteHashTable countByEnumeratingWithState].  The `NSHashtable` can store the weak reference of Mixpanel instance, but in this case it's not necessary. 

issue:
https://github.com/mixpanel/mixpanel-iphone/issues/867