### PR TITLE
Fix NSJSONSerialization crash in iOS 13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_install:
   - gem install fourflusher
   - gem uninstall cocoapods --force -a -q -I -x
   - gem install cocoapods -v 1.6.1
-osx_image: xcode11
+osx_image: xcode12
 branches:
   only:
   - master
@@ -13,8 +13,8 @@ env:
   - WORKSPACE="HelloMixpanel/HelloMixpanel.xcworkspace"
   - SCHEME="[iOS] HelloMixpanel"
   matrix:
-    - DESTINATION="OS=13.0,name=iPad Pro (11-inch)" RUN_TESTS="YES" POD_LINT="YES"
-    - DESTINATION="OS=13.0,name=iPhone 11" RUN_TESTS="YES" POD_LINT="YES" 
+    - DESTINATION="OS=13.0,name=iPad Pro (9.7-inch)" RUN_TESTS="YES" POD_LINT="YES"
+    - DESTINATION="OS=14.0,name=iPhone 11" RUN_TESTS="YES" POD_LINT="YES" 
 podfile: HelloMixpanel/podfile
 script:
 - set -o pipefail

--- a/HelloMixpanel/HelloMixpanel/AppDelegate.m
+++ b/HelloMixpanel/HelloMixpanel/AppDelegate.m
@@ -52,18 +52,6 @@
     // Force a flush to make debugging easier
     [self.mixpanel flush];
 
-    if ([UNUserNotificationCenter class]) {
-        UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
-        center.delegate = self;
-        [center requestAuthorizationWithOptions:(UNAuthorizationOptionSound | UNAuthorizationOptionAlert | UNAuthorizationOptionBadge)
-                              completionHandler:^(BOOL granted, NSError * _Nullable error) {
-            if (!error) {
-                dispatch_async(dispatch_get_main_queue(), ^{
-                    [[UIApplication sharedApplication] registerForRemoteNotifications];
-                });
-            }
-        }];
-    }
 
     return YES;
 }

--- a/HelloMixpanel/HelloMixpanel/HelloMixpanel.storyboard
+++ b/HelloMixpanel/HelloMixpanel/HelloMixpanel.storyboard
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="Uq2-fg-yt9">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="Uq2-fg-yt9">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -114,7 +115,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5nz-Tb-Vkj">
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5nz-Tb-Vkj">
                                 <rect key="frame" x="71" y="202" width="33" height="30"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Start">
@@ -127,7 +128,7 @@
                                     <action selector="start:" destination="xYk-qi-taq" eventType="touchUpInside" id="BfR-zW-Ulj"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NqI-JX-Jvq">
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NqI-JX-Jvq">
                                 <rect key="frame" x="215" y="202" width="37" height="30"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Track">
@@ -199,7 +200,7 @@
                                                     <rect key="frame" x="16" y="0.0" width="324" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="18"/>
-                                                    <color key="textColor" systemColor="systemBlueColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <color key="textColor" systemColor="systemBlueColor"/>
                                                     <nil key="highlightedColor"/>
                                                     <userDefinedRuntimeAttributes>
                                                         <userDefinedRuntimeAttribute type="string" keyPath="mixpanelViewId" value="mp-label-OC3-Xs-814"/>
@@ -222,7 +223,7 @@
                                                     <rect key="frame" x="16" y="0.0" width="324" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="18"/>
-                                                    <color key="textColor" systemColor="systemBlueColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <color key="textColor" systemColor="systemBlueColor"/>
                                                     <nil key="highlightedColor"/>
                                                     <userDefinedRuntimeAttributes>
                                                         <userDefinedRuntimeAttribute type="string" keyPath="mixpanelViewId" value="mp-label-OC3-Xs-814"/>
@@ -245,7 +246,7 @@
                                                     <rect key="frame" x="16" y="0.0" width="324" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="18"/>
-                                                    <color key="textColor" systemColor="systemBlueColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <color key="textColor" systemColor="systemBlueColor"/>
                                                     <nil key="highlightedColor"/>
                                                     <userDefinedRuntimeAttributes>
                                                         <userDefinedRuntimeAttribute type="string" keyPath="mixpanelViewId" value="mp-label-OC3-Xs-814"/>
@@ -268,7 +269,7 @@
                                                     <rect key="frame" x="16" y="0.0" width="324" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="18"/>
-                                                    <color key="textColor" systemColor="systemBlueColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <color key="textColor" systemColor="systemBlueColor"/>
                                                     <nil key="highlightedColor"/>
                                                     <userDefinedRuntimeAttributes>
                                                         <userDefinedRuntimeAttribute type="string" keyPath="mixpanelViewId" value="mp-label-OC3-Xs-814"/>
@@ -291,7 +292,7 @@
                                                     <rect key="frame" x="16" y="0.0" width="324" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="18"/>
-                                                    <color key="textColor" systemColor="systemBlueColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <color key="textColor" systemColor="systemBlueColor"/>
                                                     <nil key="highlightedColor"/>
                                                     <userDefinedRuntimeAttributes>
                                                         <userDefinedRuntimeAttribute type="string" keyPath="mixpanelViewId" value="mp-label-CJv-3C-4Lz"/>
@@ -314,7 +315,7 @@
                                                     <rect key="frame" x="16" y="0.0" width="324" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="18"/>
-                                                    <color key="textColor" systemColor="systemBlueColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <color key="textColor" systemColor="systemBlueColor"/>
                                                     <nil key="highlightedColor"/>
                                                     <userDefinedRuntimeAttributes>
                                                         <userDefinedRuntimeAttribute type="string" keyPath="mixpanelViewId" value="mp-label-D3f-sr-A1P"/>
@@ -337,7 +338,7 @@
                                                     <rect key="frame" x="16" y="0.0" width="324" height="56"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="18"/>
-                                                    <color key="textColor" systemColor="systemBlueColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <color key="textColor" systemColor="systemBlueColor"/>
                                                     <nil key="highlightedColor"/>
                                                     <userDefinedRuntimeAttributes>
                                                         <userDefinedRuntimeAttribute type="string" keyPath="mixpanelViewId" value="mp-label-1x8-g3-DoV"/>
@@ -360,7 +361,7 @@
                                                     <rect key="frame" x="16" y="0.0" width="324" height="56"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="18"/>
-                                                    <color key="textColor" systemColor="systemBlueColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <color key="textColor" systemColor="systemBlueColor"/>
                                                     <nil key="highlightedColor"/>
                                                     <userDefinedRuntimeAttributes>
                                                         <userDefinedRuntimeAttribute type="string" keyPath="mixpanelViewId" value="mp-label-1x8-g3-DoV"/>
@@ -500,7 +501,7 @@
                                     <userDefinedRuntimeAttribute type="string" keyPath="mixpanelViewId" value="mp-imageView-jGo-oH-Gk5"/>
                                 </userDefinedRuntimeAttributes>
                             </imageView>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="e9B-Gc-zhT">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="e9B-Gc-zhT">
                                 <rect key="frame" x="97.5" y="164" width="180" height="21"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="180" id="LHS-Wy-u6c"/>
@@ -544,7 +545,7 @@
                                     <action selector="setNotificationType:" destination="PAi-oO-Noz" eventType="valueChanged" id="5xi-Es-mQk"/>
                                 </connections>
                             </segmentedControl>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hvb-ez-zdi">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hvb-ez-zdi">
                                 <rect key="frame" x="97.5" y="193" width="180" height="21"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="21" id="htx-sh-cga"/>
@@ -562,6 +563,13 @@
                                     <action selector="changeBackground" destination="PAi-oO-Noz" eventType="touchUpInside" id="GVf-TM-LqN"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tqE-oz-ZdM" userLabel="Request notification permission">
+                                <rect key="frame" x="79.5" y="235" width="216" height="30"/>
+                                <state key="normal" title="Request notification permission"/>
+                                <connections>
+                                    <action selector="requestNotificationPermission:" destination="PAi-oO-Noz" eventType="touchUpInside" id="fDS-cL-5i7"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
@@ -574,7 +582,9 @@
                             <constraint firstAttribute="trailing" secondItem="jGo-oH-Gk5" secondAttribute="trailing" id="K8m-QA-f46"/>
                             <constraint firstAttribute="centerX" secondItem="auC-4E-3iO" secondAttribute="centerX" id="M5c-Yo-Ugz"/>
                             <constraint firstItem="Eka-Dd-tSy" firstAttribute="top" secondItem="jGo-oH-Gk5" secondAttribute="bottom" id="Mrn-HA-fI9"/>
+                            <constraint firstItem="tqE-oz-ZdM" firstAttribute="centerX" secondItem="hvb-ez-zdi" secondAttribute="centerX" id="NPc-vC-1WA"/>
                             <constraint firstItem="jGo-oH-Gk5" firstAttribute="top" secondItem="Efi-Hy-TDA" secondAttribute="top" id="RoE-aN-Ik8"/>
+                            <constraint firstItem="tqE-oz-ZdM" firstAttribute="top" secondItem="hvb-ez-zdi" secondAttribute="bottom" constant="21" id="dnd-UW-c2p"/>
                             <constraint firstAttribute="centerX" secondItem="Ews-8i-K8A" secondAttribute="centerX" id="ef0-qR-N4Y"/>
                             <constraint firstAttribute="centerX" secondItem="e9B-Gc-zhT" secondAttribute="centerX" id="ooN-If-c1d"/>
                             <constraint firstItem="auC-4E-3iO" firstAttribute="top" secondItem="Ews-8i-K8A" secondAttribute="bottom" constant="18" id="ytt-Jb-Htd"/>
@@ -605,7 +615,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="CoZ-lb-2Y5">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="CoZ-lb-2Y5">
                                 <rect key="frame" x="160.5" y="286.5" width="54" height="30"/>
                                 <state key="normal" title="Dismiss">
                                     <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -618,7 +628,7 @@
                                 </connections>
                             </button>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label with constraints" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AZb-DT-cbh">
-                                <rect key="frame" x="104.5" y="360.5" width="167.5" height="20.5"/>
+                                <rect key="frame" x="105" y="360.5" width="166.5" height="20.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
@@ -627,7 +637,7 @@
                                 </userDefinedRuntimeAttributes>
                             </label>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Constraints" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VVc-oe-1mi">
-                                <rect key="frame" x="184" y="522.5" width="88" height="20.5"/>
+                                <rect key="frame" x="183.5" y="522.5" width="88" height="20.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
@@ -677,7 +687,7 @@
                                     <userDefinedRuntimeAttribute type="string" keyPath="mixpanelViewId" value="mp-label-sEU-Eo-c2O"/>
                                 </userDefinedRuntimeAttributes>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tvE-69-z87">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tvE-69-z87">
                                 <rect key="frame" x="110.5" y="49" width="154" height="30"/>
                                 <state key="normal" title="Button with a long title">
                                     <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -695,7 +705,7 @@
                                     <userDefinedRuntimeAttribute type="string" keyPath="mixpanelViewId" value="mp-stepper-l3e-1K-yxm"/>
                                 </userDefinedRuntimeAttributes>
                             </stepper>
-                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="OAo-lJ-2UW">
+                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="OAo-lJ-2UW">
                                 <rect key="frame" x="306" y="86" width="51" height="31"/>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="string" keyPath="mixpanelViewId" value="mp-switch-OAo-lJ-2UW"/>
@@ -711,13 +721,13 @@
                                     <userDefinedRuntimeAttribute type="string" keyPath="mixpanelViewId" value="mp-segmentedControl-YWo-CI-4Ue"/>
                                 </userDefinedRuntimeAttributes>
                             </segmentedControl>
-                            <pageControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" numberOfPages="3" translatesAutoresizingMaskIntoConstraints="NO" id="HV0-wq-yAr">
-                                <rect key="frame" x="162" y="83" width="94" height="37"/>
+                            <pageControl opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" numberOfPages="3" translatesAutoresizingMaskIntoConstraints="NO" id="HV0-wq-yAr">
+                                <rect key="frame" x="162" y="88" width="94" height="27.5"/>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="string" keyPath="mixpanelViewId" value="mp-pageControl-HV0-wq-yAr"/>
                                 </userDefinedRuntimeAttributes>
                             </pageControl>
-                            <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="NPd-jX-jFD">
+                            <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" ambiguous="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="NPd-jX-jFD">
                                 <rect key="frame" x="269" y="91.5" width="20" height="20"/>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="string" keyPath="mixpanelViewId" value="mp-activityIndicatorView-NPd-jX-jFD"/>
@@ -813,7 +823,7 @@ Incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostr
                                 </userDefinedRuntimeAttributes>
                             </textView>
                             <progressView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" progress="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="YgV-bM-dil">
-                                <rect key="frame" x="20" y="10" width="335" height="2"/>
+                                <rect key="frame" x="20" y="10" width="335" height="4"/>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="string" keyPath="mixpanelViewId" value="mp-progressView-YgV-bM-dil"/>
                                 </userDefinedRuntimeAttributes>
@@ -1119,7 +1129,7 @@ Incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostr
                                     <userDefinedRuntimeAttribute type="string" keyPath="mixpanelViewId" value="mp-label-4xb-bA-KXH"/>
                                 </userDefinedRuntimeAttributes>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="SNk-YS-2S2">
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="SNk-YS-2S2">
                                 <rect key="frame" x="82" y="334" width="156" height="30"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Present Modal">
@@ -1132,7 +1142,7 @@ Incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostr
                                     <segue destination="9cb-wX-AKx" kind="modal" identifier="PresentModal" id="Whc-DY-5P5"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ale-TE-MhX">
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ale-TE-MhX">
                                 <rect key="frame" x="82" y="372" width="156" height="30"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Push Kitchen Sink">
@@ -1155,7 +1165,7 @@ Incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostr
                                     <userDefinedRuntimeAttribute type="string" keyPath="mixpanelViewId" value="mp-label-2FA-bp-70L"/>
                                 </userDefinedRuntimeAttributes>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yP3-UX-Czn">
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yP3-UX-Czn">
                                 <rect key="frame" x="95" y="410" width="131" height="30"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Join available tests">
@@ -1332,5 +1342,8 @@ Incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostr
         <image name="Icon.png" width="57" height="57"/>
         <image name="Like" width="25" height="25"/>
         <image name="MPLogo" width="25" height="25"/>
+        <systemColor name="systemBlueColor">
+            <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
     </resources>
 </document>

--- a/HelloMixpanel/HelloMixpanel/ViewController.m
+++ b/HelloMixpanel/HelloMixpanel/ViewController.m
@@ -75,6 +75,22 @@
     }
 }
 
+- (IBAction)requestNotificationPermission:(id)sender
+{
+    if ([UNUserNotificationCenter class]) {
+        UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+        center.delegate = self;
+        [center requestAuthorizationWithOptions:(UNAuthorizationOptionSound | UNAuthorizationOptionAlert | UNAuthorizationOptionBadge)
+                              completionHandler:^(BOOL granted, NSError * _Nullable error) {
+            if (!error) {
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    [[UIApplication sharedApplication] registerForRemoteNotifications];
+                });
+            }
+        }];
+    }
+}
+
 - (IBAction)setNotificationType:(id)sender
 {
     NSArray *types = @[@"takeover", @"mini"];

--- a/HelloMixpanel/HelloMixpanelTests/HelloMixpanelTests.m
+++ b/HelloMixpanel/HelloMixpanelTests/HelloMixpanelTests.m
@@ -77,7 +77,6 @@
 - (void)testFlushPeople {
     stubTrack();
     stubEngage();
-
     [self.mixpanel identify:@"d1"];
     for (NSUInteger i=0, n=50; i<n; i++) {
         [self.mixpanel.people set:@"p1" to:[NSString stringWithFormat:@"%lu", (unsigned long)i]];

--- a/HelloMixpanel/HelloMixpanelTests/MPNetworkTests.m
+++ b/HelloMixpanel/HelloMixpanelTests/MPNetworkTests.m
@@ -144,6 +144,17 @@
 }
 
 //
+// Encoding corrupted string to JSON strings should not crash
+//
+- (void)testEncodeCorruptedJSON {
+    NSString *utf8String = @"🇹🇲🇧🇹🇨🇫";
+    NSString *corruptedString = [utf8String substringToIndex:1];
+    NSArray *events = @[@{ @"corruptedString": corruptedString, @"utf8String": utf8String}];
+    NSData *data = [MPNetwork encodeArrayAsJSONData:events];
+    XCTAssert(data != nil, @"Encode JSON data should not crash and return nil result");
+}
+
+//
 // Encoding arrays for API should go to JSON, then Base64, and match our final expectations
 //
 - (void)testEncodeAPI {

--- a/HelloMixpanel/HelloMixpanelTests/MPNotificationTests.m
+++ b/HelloMixpanel/HelloMixpanelTests/MPNotificationTests.m
@@ -206,7 +206,7 @@
 
 - (void)testNoDoubleShowNotification {
     [[LSNocilla sharedInstance] stop];
-
+    stubRequest(@"GET", @"https://cdn.mxpnl.com/site_media/images/engage/inapp_messages/mini/icon_coin@2x.png");
     NSData *notificationData = [@"{\"id\": 1234, \"message_id\": 4444, \"title\": \"This is a title\", \"title_color\": 4294901760, \"body\": \"This is a body\", \"body_color\": 4294901760, \"image_url\": \"https://cdn.mxpnl.com/site_media/images/engage/inapp_messages/mini/icon_coin.png\", \"close_color\": 4294901760, \"type\": \"takeover\", \"bg_color\": 0, \"buttons\": [{\"bg_color\": 0, \"text\": \"Yes!\", \"border_color\": 4294901760, \"text_color\": 4294901760, \"cta_url\": \"mixpanel://deeplink/howareyou\"}],\"extras\": {\"image_fade\": true}}" dataUsingEncoding:NSUTF8StringEncoding];
     NSDictionary *notifDict = [NSJSONSerialization JSONObjectWithData:notificationData options:0 error:nil];
 
@@ -247,7 +247,7 @@
 
 - (void)testNoShowNotificationOnAlertController {
     [[LSNocilla sharedInstance] stop];
-    
+    stubRequest(@"GET", @"https://cdn.mxpnl.com/site_media/images/engage/inapp_messages/mini/icon_coin@2x.png");
     UIViewController *topVC = [self topViewController];
     
     UIAlertController *alertController = [UIAlertController alertControllerWithTitle:@"Alert" message:nil preferredStyle:UIAlertControllerStyleAlert];

--- a/Mixpanel/MPNetwork.m
+++ b/Mixpanel/MPNetwork.m
@@ -296,8 +296,19 @@ static const NSUInteger kBatchSize = 50;
 }
 
 + (id)convertFoundationTypesToJSON:(id)obj {
+    // check if the NSString is a valid UTF-8 string
+    if ([obj isKindOfClass:NSString.class]) {
+        obj = (NSString *)obj;
+        if ([obj UTF8String] == nil) {
+            // not a valid UTF-8 string
+            // we will use the replacement char '\uFFFD' to prevent nil and crash
+            obj = @"\ufffd";
+            MPLogWarning(@"property value got invalid UTF-8 string");
+        }
+        return obj;
+    }
     // valid json types
-    if ([obj isKindOfClass:NSString.class] || [obj isKindOfClass:NSNumber.class] || [obj isKindOfClass:NSNull.class]) {
+    if ([obj isKindOfClass:NSNumber.class] || [obj isKindOfClass:NSNull.class]) {
         return obj;
     }
     


### PR DESCRIPTION
This is to address https://github.com/mixpanel/mixpanel-iphone/issues/909 (Crashes in encodeArrayForAPI: and convertFoundationTypesToJSON: under iOS 13)

In iOS 13 there is a bug for `encodeArrayAsJSONData:` if the input `array` in `encodeArrayAsJSONData:(NSArray *)array` contains corrupted characters(not valid UTF-8), it will lead to a crash. see radar https://openradar.appspot.com/radar?id=4964054569320448  (NSJSONSerialization crashes on iOS 13) The fix is to check whether the string is a valid UTF-8 before sending to Mixpanel. Mixpanel backend can only handle UTF-8 string.