### PR TITLE
migrate to Airship 14.0 for the Urban Airship integration 

### DIFF
--- a/Mixpanel/MPConnectIntegrations.m
+++ b/Mixpanel/MPConnectIntegrations.m
@@ -50,7 +50,7 @@ static const NSInteger UA_MAX_RETRIES = 3;
     if (urbanAirship) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
-        NSString *channelID = [[urbanAirship performSelector:NSSelectorFromString(@"push")] performSelector:NSSelectorFromString(@"channelID")];
+        NSString *channelID = [[urbanAirship performSelector:NSSelectorFromString(@"channel")] performSelector:NSSelectorFromString(@"identifier")];
 #pragma clang diagnostic pop
         if (!channelID.length) {
             self.urbanAirshipRetries++;


### PR DESCRIPTION
address #938 

Fix crash when integrating with urbanairship 14.0+ due to `UAirship push channelID` has been removed and changed to `UAirship channel identifier`. The fix was to `UAirship.push().channelID -> UAirship.channel().identifier)`

For more details:
https://github.com/urbanairship/ios-library/blob/main/Documentation/Migration/migration-guide-13-14.md