### PR TITLE
Set `automaticPushTracking` and `trackCrashes` to NO by default when init the SDK

### DIFF
--- a/HelloMixpanel/HelloMixpanelTests/HelloMixpanelTests.m
+++ b/HelloMixpanel/HelloMixpanelTests/HelloMixpanelTests.m
@@ -436,6 +436,7 @@
     self.mixpanel = [[Mixpanel alloc] initWithToken:kTestToken
                                       launchOptions:launchOptions
                                    andFlushInterval:60];
+    self.mixpanel = [[Mixpanel alloc] initWithToken:kTestToken launchOptions:launchOptions flushInterval:60 trackCrashes:YES automaticPushTracking:YES];
     [self waitForMixpanelQueues];
     NSDictionary *e = self.mixpanel.eventsQueue.lastObject;
     XCTAssertEqualObjects(e[@"event"], @"$app_open", @"incorrect event name");

--- a/HelloMixpanel/HelloMixpanelTests/MixpanelOptOutTests.m
+++ b/HelloMixpanel/HelloMixpanelTests/MixpanelOptOutTests.m
@@ -83,7 +83,7 @@
                                              }
                                      };
     
-    self.mixpanel = [Mixpanel sharedInstanceWithToken:[self randomTokenId] launchOptions:launchOptions trackCrashes:YES automaticPushTracking:YES optOutTrackingByDefault:YES];
+    self.mixpanel = [Mixpanel sharedInstanceWithToken:[self randomTokenId] launchOptions:launchOptions trackCrashes:NO automaticPushTracking:NO optOutTrackingByDefault:YES];
     [self waitForMixpanelQueues];
     XCTAssertTrue(self.mixpanel.eventsQueue.count == 0, @"no event should be queued");
     XCTAssertTrue(trackCount == 0, @"When opted out, no track call should be ever triggered during initialization.");
@@ -104,7 +104,7 @@
                                              }
                                      };
     
-    self.mixpanel = [Mixpanel sharedInstanceWithToken:[self randomTokenId] launchOptions:launchOptions trackCrashes:YES automaticPushTracking:YES optOutTrackingByDefault:NO];
+    self.mixpanel = [Mixpanel sharedInstanceWithToken:[self randomTokenId] launchOptions:launchOptions trackCrashes:NO automaticPushTracking:YES optOutTrackingByDefault:NO];
     [self waitForMixpanelQueues];
     NSDictionary *e = self.mixpanel.eventsQueue.lastObject;
     XCTAssertEqualObjects(e[@"event"], @"$app_open", @"incorrect event name");

--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -71,7 +71,7 @@ static CTTelephonyNetworkInfo *telephonyInfo;
 
 + (Mixpanel *)sharedInstanceWithToken:(NSString *)apiToken launchOptions:(NSDictionary *)launchOptions
 {
-    return [Mixpanel sharedInstanceWithToken:apiToken launchOptions:launchOptions trackCrashes:YES automaticPushTracking:YES];
+    return [Mixpanel sharedInstanceWithToken:apiToken launchOptions:launchOptions trackCrashes:NO automaticPushTracking:NO];
 }
 
 + (Mixpanel *)sharedInstanceWithToken:(NSString *)apiToken
@@ -81,7 +81,7 @@ static CTTelephonyNetworkInfo *telephonyInfo;
 
 + (Mixpanel *)sharedInstanceWithToken:(NSString *)apiToken optOutTrackingByDefault:(BOOL)optOutTrackingByDefault
 {
-    return [Mixpanel sharedInstanceWithToken:apiToken launchOptions:nil trackCrashes:YES automaticPushTracking:YES optOutTrackingByDefault:optOutTrackingByDefault];
+    return [Mixpanel sharedInstanceWithToken:apiToken launchOptions:nil trackCrashes:NO automaticPushTracking:NO optOutTrackingByDefault:optOutTrackingByDefault];
 }
 
 + (nullable Mixpanel *)sharedInstance
@@ -237,7 +237,7 @@ static CTTelephonyNetworkInfo *telephonyInfo;
     return [self initWithToken:apiToken
                  launchOptions:launchOptions
                  flushInterval:flushInterval
-                  trackCrashes:YES];
+                  trackCrashes:NO];
 }
 
 - (instancetype)initWithToken:(NSString *)apiToken
@@ -249,7 +249,7 @@ static CTTelephonyNetworkInfo *telephonyInfo;
                  launchOptions:launchOptions
                  flushInterval:flushInterval
                   trackCrashes:trackCrashes
-         automaticPushTracking:YES];
+         automaticPushTracking:NO];
 }
 
 - (instancetype)initWithToken:(NSString *)apiToken andFlushInterval:(NSUInteger)flushInterval


### PR DESCRIPTION
We are deprecating Messaging and Mobile A/B testing features([more details](https://mixpanel.com/blog/why-were-sunsetting-messaging-and-experiments/)). Starting from the next version, we will not automatically track pushes sent from Mixpanel and crashes by default. However, you can still opt-in them by calling 
```
+ (Mixpanel *)sharedInstanceWithToken:(NSString *)apiToken launchOptions:(nullable NSDictionary *)launchOptions trackCrashes:(BOOL)trackCrashes automaticPushTracking:(BOOL)automaticPushTracking;
```
and set `trackCrashes` and `automaticPushTracking` to YES.
