### PR TITLE
NSSecureCoding Implementation

### DIFF
--- a/Mixpanel/MPEventBinding.h
+++ b/Mixpanel/MPEventBinding.h
@@ -9,7 +9,7 @@
 #import <Foundation/Foundation.h>
 #import "MPObjectSelector.h"
 
-@interface MPEventBinding : NSObject <NSCoding>
+@interface MPEventBinding : NSObject <NSSecureCoding>
 
 @property (nonatomic) NSUInteger ID;
 @property (nonatomic, copy) NSString *name;

--- a/Mixpanel/MPEventBinding.m
+++ b/Mixpanel/MPEventBinding.m
@@ -87,14 +87,18 @@
 
 #pragma mark -- NSCoder
 
++ (BOOL)supportsSecureCoding {
+    return YES;
+}
+
 - (instancetype)initWithCoder:(NSCoder *)aDecoder
 {
-    NSString *path = [aDecoder decodeObjectForKey:@"path"];
-    NSString *eventName = [aDecoder decodeObjectForKey:@"eventName"];
+    NSString *path = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"path"];
+    NSString *eventName = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"eventName"];
     if (self = [self initWithEventName:eventName onPath:path]) {
-        self.ID = [[aDecoder decodeObjectForKey:@"ID"] unsignedLongValue];
-        self.name = [aDecoder decodeObjectForKey:@"name"];
-        self.swizzleClass = NSClassFromString([aDecoder decodeObjectForKey:@"swizzleClass"]);
+        self.ID = [[aDecoder decodeObjectOfClass:[NSNumber class] forKey:@"ID"] unsignedLongValue];
+        self.name = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"name"];
+        self.swizzleClass = NSClassFromString([aDecoder decodeObjectOfClass:[NSString class] forKey:@"swizzleClass"]);
     }
     return self;
 }

--- a/Mixpanel/MPUIControlBinding.m
+++ b/Mixpanel/MPUIControlBinding.m
@@ -248,8 +248,8 @@
 - (instancetype)initWithCoder:(NSCoder *)aDecoder
 {
     if (self = [super initWithCoder:aDecoder]) {
-        _controlEvent = [[aDecoder decodeObjectForKey:@"controlEvent"] unsignedIntegerValue];
-        _verifyEvent = [[aDecoder decodeObjectForKey:@"verifyEvent"] unsignedIntegerValue];
+        _controlEvent = [[aDecoder decodeObjectOfClass:[NSNumber class] forKey:@"controlEvent"] unsignedIntegerValue];
+        _verifyEvent = [[aDecoder  decodeObjectOfClass:[NSNumber class] forKey:@"verifyEvent"] unsignedIntegerValue];
     }
     return self;
 }

--- a/Mixpanel/MPVariant.h
+++ b/Mixpanel/MPVariant.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-@interface MPVariant : NSObject <NSCoding>
+@interface MPVariant : NSObject <NSSecureCoding>
 
 @property (nonatomic) NSUInteger ID;
 @property (nonatomic) NSUInteger experimentID;
@@ -72,10 +72,10 @@
 
 @end
 
-@interface MPVariantAction : NSObject <NSCoding>
+@interface MPVariantAction : NSObject <NSSecureCoding>
 
 @end
 
-@interface MPVariantTweak : NSObject <NSCoding>
+@interface MPVariantTweak : NSObject <NSSecureCoding>
 
 @end

--- a/Mixpanel/MPVariant.m
+++ b/Mixpanel/MPVariant.m
@@ -132,14 +132,18 @@
 
 #pragma mark NSCoding
 
++ (BOOL)supportsSecureCoding {
+    return YES;
+}
+
 - (instancetype)initWithCoder:(NSCoder *)aDecoder
 {
     if (self = [super init]) {
-        self.ID = [(NSNumber *)[aDecoder decodeObjectForKey:@"ID"] unsignedLongValue];
-        self.experimentID = [(NSNumber *)[aDecoder decodeObjectForKey:@"experimentID"] unsignedLongValue];
-        self.actions = [aDecoder decodeObjectForKey:@"actions"];
-        self.tweaks = [aDecoder decodeObjectForKey:@"tweaks"];
-        _finished = [(NSNumber *)[aDecoder decodeObjectForKey:@"finished"] boolValue];
+        self.ID = [(NSNumber *)[aDecoder decodeObjectOfClass:[NSNumber class] forKey:@"ID"] unsignedLongValue];
+        self.experimentID = [(NSNumber *)[aDecoder  decodeObjectOfClass:[NSNumber class] forKey:@"experimentID"] unsignedLongValue];
+        self.actions = [aDecoder decodeObjectOfClass:[NSMutableOrderedSet class] forKey:@"actions"];
+        self.tweaks = [aDecoder  decodeObjectOfClass:[NSMutableArray class] forKey:@"tweaks"];
+        _finished = [(NSNumber *)[aDecoder decodeObjectOfClass:[NSNumber class] forKey:@"finished"] boolValue];
     }
     return self;
 }
@@ -395,19 +399,23 @@ static NSMapTable *originalCache;
 
 #pragma mark NSCoding
 
++ (BOOL)supportsSecureCoding {
+    return YES;
+}
+
 - (instancetype)initWithCoder:(NSCoder *)aDecoder
 {
     if (self = [super init]) {
-        self.name = [aDecoder decodeObjectForKey:@"name"];
+        self.name = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"name"];
 
-        self.path = [MPObjectSelector objectSelectorWithString:[aDecoder decodeObjectForKey:@"path"]];
-        self.selector = NSSelectorFromString([aDecoder decodeObjectForKey:@"selector"]);
-        self.args = [aDecoder decodeObjectForKey:@"args"];
-        self.original = [aDecoder decodeObjectForKey:@"original"];
+        self.path = [MPObjectSelector objectSelectorWithString:[aDecoder decodeObjectOfClass:[NSString class] forKey:@"path"]];
+        self.selector = NSSelectorFromString([aDecoder decodeObjectOfClass:[NSString class] forKey:@"selector"]);
+        self.args = [aDecoder decodeObjectOfClass:[NSArray class] forKey:@"args"];
+        self.original = [aDecoder decodeObjectOfClass:[NSArray class] forKey:@"original"];
 
-        self.swizzle = [(NSNumber *)[aDecoder decodeObjectForKey:@"swizzle"] boolValue];
-        self.swizzleClass = NSClassFromString([aDecoder decodeObjectForKey:@"swizzleClass"]);
-        self.swizzleSelector = NSSelectorFromString([aDecoder decodeObjectForKey:@"swizzleSelector"]);
+        self.swizzle = [(NSNumber *)[aDecoder decodeObjectOfClass:[NSNumber class] forKey:@"swizzle"] boolValue];
+        self.swizzleClass = NSClassFromString([aDecoder decodeObjectOfClass:[NSString class] forKey:@"swizzleClass"]);
+        self.swizzleSelector = NSSelectorFromString([aDecoder decodeObjectOfClass:[NSString class] forKey:@"swizzleSelector"]);
 
         self.appliedTo = [NSHashTable hashTableWithOptions:(NSHashTableWeakMemory|NSHashTableObjectPointerPersonality)];
     }
@@ -679,12 +687,17 @@ static NSMapTable *originalCache;
 
 #pragma mark NSCoding
 
++ (BOOL)supportsSecureCoding {
+    return YES;
+}
+
 - (instancetype)initWithCoder:(NSCoder *)aDecoder
 {
     if (self = [super init]) {
-        self.name = [aDecoder decodeObjectForKey:@"name"];
-        self.encoding = [aDecoder decodeObjectForKey:@"encoding"];
-        self.value = [aDecoder decodeObjectForKey:@"value"];
+        self.name = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"name"];
+        self.encoding = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"encoding"];
+        // This could be made more secure with more clarification around the class expectations
+        self.value = [aDecoder decodeObjectOfClass:[NSObject class] forKey:@"value"];
     }
     return self;
 }


### PR DESCRIPTION
**What:**

This patch puts Mixpanel in conformance with NSSecureCoding and should stop warnings (and possibly some crashes) about non-compliance.

**Why:**

Warnings were getting concerning and possible security matters are important to address. Also, there appears to possibly be a crasher with iOS 15.1 when not using secure coding. This last part is still speculative and I am investigating.

**How:**

This implementation, I believe, conforms to the "letter of the law" of NSSecureCoding, and makes progress on the "spirit" of the law. The change adds conformance to NSSecureCoding by adding "+ (BOOL)supportsSecureCoding", use of "-decodeObjectOfClass:forKey:", and changing the protocol from NSCoding to NSSecureCoding.

I'm implementing this to reduce warnings about lack of NSSecureCoding and to investigate a possible fix to a NSCoding crash I'm seeing on iOS 15.1 beta.

**Possible issues**
1. I applied this to master and only later realized I was unsure about the branching strategy and the use of 4.0.0.beta. It's possible I messed up in such a way this needs to be redone. Presumably anyone reading this at mixpanel understands the branching situation better than I.
2. Someone who understands the implementation better should probably clamp down more on MPTweakValue given that it seems that may just be intended to store a basic type.
3. This change is, as of this moment, untested other than compilation. I'm going to push out a TestFlight build of my app that uses it to try it out shortly.