### PR TITLE
Carrier name retrieval

### DIFF
--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -1655,7 +1655,18 @@ typedef NSDictionary*(^PropertyUpdate)(NSDictionary*);
     if (![Mixpanel isAppExtension]) {
         CTCarrier *carrier = nil;
         if (@available(iOS 12, *)) {
-            carrier = [[telephonyInfo serviceSubscriberCellularProviders] allValues].firstObject;
+            NSArray *carriers = [[telephonyInfo serviceSubscriberCellularProviders] allValues];
+            // Find the first carrier object that has a non-empty name
+            for (CTCarrier *carrierCandidate in carriers) {
+                if (carrierCandidate.carrierName.length != 0) {
+                    carrier = carrierCandidate;
+                    break;
+                }
+            }
+            // Use the first object as default in case there are no carriers with a name
+            if (carrier == nil) {
+                carrier = carriers.firstObject;
+            }
         } else {
             carrier = [telephonyInfo subscriberCellularProvider];
         }

--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -1663,7 +1663,7 @@ typedef NSDictionary*(^PropertyUpdate)(NSDictionary*);
                     break;
                 }
             }
-            // Use the first object as default in case there are no carriers with a name
+            // Use the first object as fallback in case there are no carriers with a name
             if (carrier == nil) {
                 carrier = carriers.firstObject;
             }


### PR DESCRIPTION
**Overview**
This PR updates logic for retrieving **$carrier** property to try to find the carrier that has a name that is not empty. 
More details on the reasoning behind the following change are described in this issue https://github.com/mixpanel/mixpanel-iphone/issues/949

**Changes**
In order to reduce the number of events where **$carrier** is `undefined` now it iterates over a collection of carriers and tries to find some that name is not empty. Once the proper carrier is found it breaks the loop. In case all carriers don't have a name it uses the first object as a fallback to be in line with previous logic.
