### PR TITLE
Add NSSecureCoding allowed classes to avoid warning

### DIFF
--- a/Sources/MixpanelPersistence.m
+++ b/Sources/MixpanelPersistence.m
@@ -361,7 +361,11 @@ static NSString *const kDefaultKeyHadPersistedDistinctId = @"MPHadPersistedDisti
         if (@available(iOS 11, macOS 10.13, tvOS 11, watchOS 4, *)) {
             NSError *error = nil;
             NSData *data = [NSData dataWithContentsOfFile:filePath];
-            unarchivedData = [NSKeyedUnarchiver unarchivedObjectOfClass:[NSObject class] fromData:data error:&error];
+            unarchivedData = [NSKeyedUnarchiver unarchivedObjectOfClasses:
+                              [NSSet setWithArray:@[[NSArray class], [NSDictionary class],
+                                                    [NSString class], [NSDate class], [NSURL class],
+                                                    [NSNumber class], [NSNull class]]]
+                                                                 fromData:data error:&error];
             if (error) {
                 MPLogError(@"%@ got error while unarchiving data in %@: %@", self, filePath, error);
             }


### PR DESCRIPTION
Fix the warning
`
 *** -[NSKeyedUnarchiver validateAllowedClass:forKey:]: NSSecureCoding allowed classes list contains [NSObject class], which bypasses security by allowing any Objective-C class to be implicitly decoded. Consider reducing the scope of allowed classes during decoding by listing only the classes you expect to decode, or a more specific base class than NSObject. This will become an error in the future. 
`