### PR TITLE
add [NSSet class] to unarchiveFromFile

### DIFF
--- a/Sources/MixpanelPersistence.m
+++ b/Sources/MixpanelPersistence.m
@@ -362,7 +362,7 @@ static NSString *const kDefaultKeyHadPersistedDistinctId = @"MPHadPersistedDisti
             NSError *error = nil;
             NSData *data = [NSData dataWithContentsOfFile:filePath];
             unarchivedData = [NSKeyedUnarchiver unarchivedObjectOfClasses:
-                              [NSSet setWithArray:@[[NSArray class], [NSDictionary class],
+                              [NSSet setWithArray:@[[NSArray class], [NSDictionary class], [NSSet class],
                                                     [NSString class], [NSDate class], [NSURL class],
                                                     [NSNumber class], [NSNull class]]]
                                                                  fromData:data error:&error];


### PR DESCRIPTION
`shownNotifications` were archived as an `NSSet` in the properties file, even though they won't be used, we still need to be able to unarchive them when we migrate from the legacy archive file to 4.0. This PR adds the `NSSet` class to the list of classes that can be unarchived.

Fixes: https://github.com/mixpanel/mixpanel-iphone/issues/971